### PR TITLE
fix: three correctness bugs (callees dedup, entrypoints hang, xref_matrix array arg)

### DIFF
--- a/src/ida/handlers/controlflow.rs
+++ b/src/ida/handlers/controlflow.rs
@@ -3,7 +3,7 @@
 use crate::error::ToolError;
 use crate::ida::handlers::parse_address_str;
 use crate::ida::types::{BasicBlockInfo, FunctionInfo};
-use idalib::xref::XRefQuery;
+use idalib::xref::{CodeRef, XRefQuery, XRefType};
 use idalib::IDB;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -79,17 +79,23 @@ pub fn handle_callees(idb: &Option<IDB>, addr: u64) -> Result<Vec<FunctionInfo>,
         if let Some(xref) = db.first_xref_from(current_addr, XRefQuery::ALL) {
             let mut xr = Some(xref);
             while let Some(x) = xr {
-                // Check if this is a call (code xref to a function)
-                if x.is_code() {
+                // Only follow NearCall / FarCall xrefs — skip Code(Flow) and data refs
+                let is_call = matches!(
+                    x.type_(),
+                    XRefType::Code(CodeRef::NearCall) | XRefType::Code(CodeRef::FarCall)
+                );
+                if is_call {
                     let target = x.to();
-                    if !seen.contains(&target) {
-                        if let Some(target_func) = db.function_at(target) {
-                            seen.insert(target);
+                    if let Some(target_func) = db.function_at(target) {
+                        // Deduplicate by function start address, not by xref target
+                        let callee_start = target_func.start_address();
+                        if !seen.contains(&callee_start) {
+                            seen.insert(callee_start);
                             callees.push(FunctionInfo {
-                                address: format!("{:#x}", target_func.start_address()),
+                                address: format!("{:#x}", callee_start),
                                 name: target_func
                                     .name()
-                                    .unwrap_or_else(|| format!("sub_{:x}", target)),
+                                    .unwrap_or_else(|| format!("sub_{:x}", callee_start)),
                                 size: target_func.len(),
                             });
                         }

--- a/src/ida/handlers/imports.rs
+++ b/src/ida/handlers/imports.rs
@@ -3,6 +3,7 @@
 use crate::error::ToolError;
 use crate::ida::types::{ExportInfo, ImportInfo};
 use idalib::IDB;
+use std::collections::HashSet;
 
 pub fn handle_imports(
     idb: &Option<IDB>,
@@ -75,7 +76,16 @@ pub fn handle_exports(
 pub fn handle_entrypoints(idb: &Option<IDB>) -> Result<Vec<String>, ToolError> {
     let db = idb.as_ref().ok_or(ToolError::NoDatabaseOpen)?;
 
-    let entrypoints: Vec<String> = db.entries().map(|addr| format!("{:#x}", addr)).collect();
+    // idalib's EntryPointIter has a bug: index is not incremented on success,
+    // causing infinite iteration. Break as soon as a duplicate address is seen.
+    let mut seen = HashSet::new();
+    let mut entrypoints = Vec::new();
+    for addr in db.entries() {
+        if !seen.insert(addr) {
+            break;
+        }
+        entrypoints.push(format!("{:#x}", addr));
+    }
 
     Ok(entrypoints)
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -168,16 +168,35 @@ impl IdaMcpServer {
     fn value_to_strings(value: &Value) -> Result<Vec<String>, ToolError> {
         match value {
             Value::String(s) => {
-                if s.contains(',') {
-                    Ok(s.split(',')
+                let trimmed = s.trim();
+                if trimmed.starts_with('[') {
+                    if let Ok(Value::Array(arr)) = serde_json::from_str(trimmed) {
+                        let mut out = Vec::with_capacity(arr.len());
+                        for v in &arr {
+                            match v {
+                                Value::String(s) => out.push(s.to_string()),
+                                Value::Number(n) => out.push(n.to_string()),
+                                _ => {
+                                    return Err(ToolError::IdaError(
+                                        "expected string or number".to_string(),
+                                    ))
+                                }
+                            }
+                        }
+                        return Ok(out);
+                    }
+                }
+                if trimmed.contains(',') {
+                    Ok(trimmed
+                        .split(',')
                         .map(|t| t.trim())
                         .filter(|t| !t.is_empty())
                         .map(|t| t.to_string())
                         .collect())
-                } else if s.trim().is_empty() {
+                } else if trimmed.is_empty() {
                     Err(ToolError::IdaError("empty string".to_string()))
                 } else {
-                    Ok(vec![s.to_string()])
+                    Ok(vec![trimmed.to_string()])
                 }
             }
             Value::Number(n) => Ok(vec![n.to_string()]),


### PR DESCRIPTION
## Summary

Three correctness bugs found through systematic tool testing against a real macOS binary (`/bin/echo`).

---

### Bug 1: `callees` / `callgraph` return hundreds of duplicate entries

**File:** `src/ida/handlers/controlflow.rs`

**Root cause (two issues):**
1. `is_code()` was used to filter xrefs, but `Code(Flow)` xrefs (every fall-through edge in a function) also satisfy `is_code()`. A single loop in the caller function generates hundreds of `Flow` xrefs all pointing into the same callee's body, each at a different address.
2. Deduplication used the raw xref *target address* rather than the callee function's *start address*, so the `HashSet` could not collapse multiple xrefs into the same function.

**Fix:**
- Match only `XRefType::Code(CodeRef::NearCall) | XRefType::Code(CodeRef::FarCall)`.
- Insert `target_func.start_address()` (not `target`) into the `seen` set.

**Before:** `callees(start)` → 200+ duplicate entries for the same 8 functions  
**After:** `callees(start)` → 8 unique entries

---

### Bug 2: `entrypoints` hangs forever (infinite loop)

**File:** `src/ida/handlers/imports.rs`

**Root cause:** `idalib`'s `EntryPointIter::next()` never increments `self.index` on the success path (upstream bug), so the iterator yields the same address forever. The original `.collect()` call loops until the process is killed.

**Fix:** Iterate manually with a `HashSet`; break on the first duplicate address. This cleanly terminates the loop and still returns all real entry points.

**Before:** `entrypoints` → server hangs, must be killed  
**After:** `entrypoints` → `["0x100000000"]` instantly

---

### Bug 3: `xref_matrix` rejects array arguments with "Invalid address format"

**File:** `src/server/mod.rs`

**Root cause:** Some MCP frameworks (e.g. Claude Desktop via MCP protocol) serialise a JSON array parameter as the string `["0x1000","0x2000"]` instead of a native JSON array. `value_to_strings()` fell into the string branch and tried to split on `,`, yielding `["0x1000"` as the first token — which `parse_address` correctly rejected.

**Fix:** In the `Value::String` branch, detect a leading `[` and attempt `serde_json::from_str` first. Fall back to the existing comma-split path only if that fails.

**Before:** `xref_matrix(["0x1000004c0","0x10000078c"])` → `"Invalid address format: [\"0x1000004c0\""`  
**After:** `xref_matrix(["0x1000004c0","0x10000078c"])` → correct 2×2 boolean matrix

---

## Testing

All three fixes were verified against a live `ida-mcp` server running on `/bin/echo` (macOS arm64, 11 functions):

| Tool | Before | After |
|------|--------|-------|
| `callees 0x1000004c0` | 200+ duplicates | 8 unique entries |
| `entrypoints` | infinite hang | `["0x100000000"]` |
| `xref_matrix ["0x1000004c0","0x10000078c"]` | `Invalid address format` | correct matrix |

A full systematic pass over 25+ other tools (disasm, decompile, xrefs_to/from, callers, basic_blocks, callgraph, find_paths, segments, get_bytes, strings, find_string, xrefs_to_string, imports, exports, local_types, list_globals, stack_frame, lookup_funcs, find_bytes, find_insns, search, analyze_strings, addr_info, idb_meta) confirmed no regressions.