### PR TITLE
fix: preserve raw IDB names and direct callees

### DIFF
--- a/src/ida/handlers/controlflow.rs
+++ b/src/ida/handlers/controlflow.rs
@@ -4,7 +4,7 @@ use crate::error::ToolError;
 use crate::ida::handlers::parse_address_str;
 use crate::ida::types::{BasicBlockInfo, FunctionInfo};
 use idalib::xref::{CodeRef, XRefQuery, XRefType};
-use idalib::IDB;
+use idalib::{Address, IDB};
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -60,6 +60,38 @@ pub fn handle_basic_blocks(idb: &Option<IDB>, addr: u64) -> Result<Vec<BasicBloc
     Ok(blocks)
 }
 
+fn add_callee(db: &IDB, callees: &mut Vec<FunctionInfo>, seen: &mut HashSet<u64>, target: Address) {
+    if let Some(target_func) = db.function_at(target) {
+        let callee_start = target_func.start_address();
+        if seen.insert(callee_start) {
+            callees.push(FunctionInfo {
+                address: format!("{:#x}", callee_start),
+                name: target_func
+                    .name()
+                    .unwrap_or_else(|| format!("sub_{:x}", callee_start)),
+                size: target_func.len(),
+            });
+        }
+    } else if seen.insert(target) {
+        callees.push(FunctionInfo {
+            address: format!("{:#x}", target),
+            name: db
+                .address_to_string(target)
+                .unwrap_or_else(|| format!("sub_{:x}", target)),
+            size: 0,
+        });
+    }
+}
+
+fn direct_call_target(db: &IDB, addr: Address) -> Option<Address> {
+    let insn = db.insn_at(addr)?;
+    if !insn.is_call() {
+        return None;
+    }
+
+    (0..insn.operand_count()).find_map(|idx| insn.operand(idx).and_then(|op| op.address()))
+}
+
 pub fn handle_callees(idb: &Option<IDB>, addr: u64) -> Result<Vec<FunctionInfo>, ToolError> {
     let db = idb.as_ref().ok_or(ToolError::NoDatabaseOpen)?;
 
@@ -70,43 +102,40 @@ pub fn handle_callees(idb: &Option<IDB>, addr: u64) -> Result<Vec<FunctionInfo>,
     let mut callees = Vec::new();
     let mut seen = HashSet::new();
 
-    // Iterate through the function's addresses and find call xrefs
     let start = func.start_address();
     let end = func.end_address();
     let mut current_addr = start;
 
     while current_addr < end {
+        let mut found_call_xref = false;
         if let Some(xref) = db.first_xref_from(current_addr, XRefQuery::ALL) {
             let mut xr = Some(xref);
             while let Some(x) = xr {
-                // Only follow NearCall / FarCall xrefs — skip Code(Flow) and data refs
                 let is_call = matches!(
                     x.type_(),
                     XRefType::Code(CodeRef::NearCall) | XRefType::Code(CodeRef::FarCall)
                 );
                 if is_call {
-                    let target = x.to();
-                    if let Some(target_func) = db.function_at(target) {
-                        // Deduplicate by function start address, not by xref target
-                        let callee_start = target_func.start_address();
-                        if !seen.contains(&callee_start) {
-                            seen.insert(callee_start);
-                            callees.push(FunctionInfo {
-                                address: format!("{:#x}", callee_start),
-                                name: target_func
-                                    .name()
-                                    .unwrap_or_else(|| format!("sub_{:x}", callee_start)),
-                                size: target_func.len(),
-                            });
-                        }
-                    }
+                    found_call_xref = true;
+                    add_callee(db, &mut callees, &mut seen, x.to());
                 }
                 xr = x.next_from();
             }
         }
 
-        // Move to next instruction
-        if let Some(next) = db.next_head(current_addr) {
+        if !found_call_xref {
+            if let Some(target) = direct_call_target(db, current_addr) {
+                add_callee(db, &mut callees, &mut seen, target);
+            }
+        }
+
+        if let Some(insn) = db.insn_at(current_addr) {
+            let next = current_addr.saturating_add(insn.len() as u64);
+            if next <= current_addr {
+                break;
+            }
+            current_addr = next;
+        } else if let Some(next) = db.next_head(current_addr) {
             if next <= current_addr {
                 break;
             }

--- a/src/ida/handlers/controlflow.rs
+++ b/src/ida/handlers/controlflow.rs
@@ -3,6 +3,7 @@
 use crate::error::ToolError;
 use crate::ida::handlers::parse_address_str;
 use crate::ida::types::{BasicBlockInfo, FunctionInfo};
+use idalib::insn::OperandType;
 use idalib::xref::{CodeRef, XRefQuery, XRefType};
 use idalib::{Address, IDB};
 use serde_json::{json, Value};
@@ -83,13 +84,29 @@ fn add_callee(db: &IDB, callees: &mut Vec<FunctionInfo>, seen: &mut HashSet<u64>
     }
 }
 
+/// Returns true for operand kinds that encode a direct branch target
+/// (e.g. `call sub_xxx`). `Mem` and `Displ` also expose an `address()`
+/// but represent indirect calls (`call qword ptr [rip+...]`,
+/// `call qword ptr [reg+disp]`); their `address()` is a load site, not
+/// a callee, so we must not treat them as direct targets.
+fn is_direct_branch_operand(kind: OperandType) -> bool {
+    matches!(kind, OperandType::Near | OperandType::Far)
+}
+
 fn direct_call_target(db: &IDB, addr: Address) -> Option<Address> {
     let insn = db.insn_at(addr)?;
     if !insn.is_call() {
         return None;
     }
 
-    (0..insn.operand_count()).find_map(|idx| insn.operand(idx).and_then(|op| op.address()))
+    (0..insn.operand_count()).find_map(|idx| {
+        let op = insn.operand(idx)?;
+        if is_direct_branch_operand(op.type_()) {
+            op.address()
+        } else {
+            None
+        }
+    })
 }
 
 pub fn handle_callees(idb: &Option<IDB>, addr: u64) -> Result<Vec<FunctionInfo>, ToolError> {
@@ -355,4 +372,33 @@ pub fn handle_callgraph(
         .collect();
 
     Ok(json!({ "nodes": nodes_vec, "edges": edges_vec }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_direct_branch_operand;
+    use idalib::insn::OperandType;
+
+    #[test]
+    fn direct_branch_operands_accept_near_and_far_only() {
+        assert!(is_direct_branch_operand(OperandType::Near));
+        assert!(is_direct_branch_operand(OperandType::Far));
+    }
+
+    #[test]
+    fn indirect_call_operands_are_rejected() {
+        // Mem  -> call qword ptr [abs_addr]
+        // Displ -> call qword ptr [reg+disp] (e.g. RIP-relative on x86-64)
+        // Phrase -> call qword ptr [reg]
+        // These all have an address() but it's a load site, not a callee.
+        assert!(!is_direct_branch_operand(OperandType::Mem));
+        assert!(!is_direct_branch_operand(OperandType::Displ));
+        assert!(!is_direct_branch_operand(OperandType::Phrase));
+    }
+
+    #[test]
+    fn non_address_operands_are_rejected() {
+        assert!(!is_direct_branch_operand(OperandType::Reg));
+        assert!(!is_direct_branch_operand(OperandType::Imm));
+    }
 }

--- a/src/ida/handlers/database.rs
+++ b/src/ida/handlers/database.rs
@@ -69,6 +69,12 @@ fn unpacked_id0_path(path: &Path) -> Option<PathBuf> {
     None
 }
 
+fn idb_path_for_raw_binary(path: &Path) -> PathBuf {
+    let mut raw_idb = OsString::from(path.as_os_str());
+    raw_idb.push(".i64");
+    PathBuf::from(raw_idb)
+}
+
 fn base_input_path_for_database(path: &Path) -> PathBuf {
     let mut base = path.to_path_buf();
     if let Some(ext) = base.extension().and_then(|e| e.to_str()) {
@@ -153,7 +159,7 @@ pub fn handle_open(
     let mut dsym_path = None;
     let mut should_load_dsym = false;
     if !is_idb {
-        let out_path = expanded.with_extension("i64");
+        let out_path = idb_path_for_raw_binary(&expanded);
         should_load_dsym = !out_path.exists();
         if should_load_dsym {
             dsym_path = dsym_path_for_binary(&expanded);
@@ -416,7 +422,8 @@ mod tests {
     use std::path::Path;
 
     use crate::ida::handlers::database::{
-        base_input_path_for_database, database_paths_match, init_database_args,
+        base_input_path_for_database, database_paths_match, idb_path_for_raw_binary,
+        init_database_args,
     };
 
     #[test]
@@ -439,6 +446,22 @@ mod tests {
         assert!(database_paths_match(unpacked, legacy));
         assert!(database_paths_match(packed_upper, unpacked));
         assert!(!database_paths_match(packed, legacy));
+    }
+
+    #[test]
+    fn idb_path_for_raw_binary_appends_i64_to_full_path() {
+        assert_eq!(
+            idb_path_for_raw_binary(Path::new("/tmp/sample")),
+            Path::new("/tmp/sample.i64")
+        );
+        assert_eq!(
+            idb_path_for_raw_binary(Path::new("/tmp/com.apple.driver.AppleDAPF")),
+            Path::new("/tmp/com.apple.driver.AppleDAPF.i64")
+        );
+        assert_eq!(
+            idb_path_for_raw_binary(Path::new("/tmp/kernelcache.release.iphone")),
+            Path::new("/tmp/kernelcache.release.iphone.i64")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,9 @@ use rmcp::transport::streamable_http_server::{
     session::local::LocalSessionManager, StreamableHttpService,
 };
 use rmcp::ServiceExt;
+use std::ffi::OsString;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -491,7 +492,7 @@ fn open_db_for_probe(path: &PathBuf, args: &ProbeArgs) -> Result<IDB, idalib::ID
         let out_path = if let Some(out) = args.idb_out.as_deref() {
             PathBuf::from(out)
         } else {
-            path.with_extension("i64")
+            idb_path_for_raw_binary(path)
         };
         info!(
             "Opening raw binary with auto-analysis (idb_out={})",
@@ -502,6 +503,12 @@ fn open_db_for_probe(path: &PathBuf, args: &ProbeArgs) -> Result<IDB, idalib::ID
         }
         opts.idb(&out_path).save(true).open(path)
     }
+}
+
+fn idb_path_for_raw_binary(path: &Path) -> PathBuf {
+    let mut raw_idb = OsString::from(path.as_os_str());
+    raw_idb.push(".i64");
+    PathBuf::from(raw_idb)
 }
 
 fn probe_init_database_args() -> Vec<String> {


### PR DESCRIPTION
## Summary
- Append `.i64` to the full raw binary path instead of replacing the final extension-like component.
- Keep MCP `open_idb` and CLI `probe` default output naming consistent.
- Include unresolved direct call targets in `callees`, which also restores those edges in `callgraph` for kext-style external calls.
- Add a regression test covering bundle-id-style filenames like `com.apple.driver.AppleDAPF`.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo build --release`
- Manual probe against two copied iOS kexts confirmed distinct outputs:
  - `com.apple.driver.AppleIDAMInterface.i64`
  - `com.apple.driver.AppleDAPF.i64`
- Manual MCP stdio verification after analysis completed confirmed:
  - `callees(0xfffffff0088bc870)` includes `0xfffffff00a3aeca0`
  - `callgraph` emits `0xfffffff0088bc870 -> 0xfffffff00a3aeca0`
  - IOSurface root `0xfffffff0097e63a4` also emits an edge to `0xfffffff00a3aeca0`