### PR TITLE
refactor: tighten close-ownership recovery

### DIFF
--- a/src/ida/worker.rs
+++ b/src/ida/worker.rs
@@ -38,12 +38,8 @@ pub(crate) struct CloseTokenGrant {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CloseAuthorization {
     Granted,
-    GrantedByOverride {
-        previous_owner_session_id: Option<String>,
-    },
-    Denied {
-        owner_session_id: Option<String>,
-    },
+    GrantedByOverride { previous_owner_session_id: String },
+    Denied { owner_session_id: String },
 }
 
 /// Internal state for close token ownership.
@@ -119,11 +115,11 @@ impl CloseTokenState {
             CloseAuthorization::Granted
         } else if force {
             CloseAuthorization::GrantedByOverride {
-                previous_owner_session_id: Some(lease.owner_session_id.clone()),
+                previous_owner_session_id: lease.owner_session_id.clone(),
             }
         } else {
             CloseAuthorization::Denied {
-                owner_session_id: Some(lease.owner_session_id.clone()),
+                owner_session_id: lease.owner_session_id.clone(),
             }
         }
     }
@@ -1235,8 +1231,30 @@ mod tests {
         assert_eq!(
             worker.authorize_close("session-b", None, true),
             CloseAuthorization::GrantedByOverride {
-                previous_owner_session_id: Some("session-a".to_string()),
+                previous_owner_session_id: "session-a".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn token_grants_close_from_any_session() {
+        let worker = test_worker();
+        let grant = worker
+            .issue_close_token_for_session("session-a")
+            .expect("first issue should succeed");
+
+        assert_eq!(
+            worker.authorize_close("session-b", Some(&grant.token), false),
+            CloseAuthorization::Granted
+        );
+    }
+
+    #[test]
+    fn close_is_granted_when_no_lease_exists() {
+        let worker = test_worker();
+        assert_eq!(
+            worker.authorize_close("session-x", None, false),
+            CloseAuthorization::Granted
         );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -133,14 +133,7 @@ impl IdaMcpServer {
     }
 
     fn close_hint(&self) -> &'static str {
-        match self.mode {
-            ServerMode::Stdio => {
-                "Call close_idb when done to release locks for other sessions."
-            }
-            ServerMode::Http => {
-                "In multi-client (HTTP/SSE) mode, close_idb accepts the close_token returned by open_idb. The owning session can also close without re-sending the token, and close_idb(force=true) can recover from a lost session."
-            }
-        }
+        close_hint_for(self.mode)
     }
 
     fn http_close_grant(&self) -> Option<Result<CloseTokenGrant, String>> {
@@ -153,40 +146,7 @@ impl IdaMcpServer {
         map: &mut serde_json::Map<String, Value>,
         grant: Option<Result<CloseTokenGrant, String>>,
     ) {
-        match grant {
-            Some(Ok(grant)) => {
-                map.insert("close_hint".to_string(), json!(self.close_hint()));
-                map.insert(
-                    "close_owner_session_id".to_string(),
-                    json!(grant.owner_session_id),
-                );
-                map.insert("close_token".to_string(), json!(grant.token));
-                if grant.reused {
-                    map.insert("close_token_reused".to_string(), json!(true));
-                }
-            }
-            Some(Err(owner_session_id)) => {
-                map.insert(
-                    "close_hint".to_string(),
-                    json!(format!(
-                        "The open database is currently owned by HTTP session {owner_session_id}. Reuse that session to call close_idb, or call close_idb(force=true) to recover if the owning session was lost."
-                    )),
-                );
-                map.insert(
-                    "close_owner_session_id".to_string(),
-                    json!(owner_session_id),
-                );
-                map.insert(
-                    "close_recovery_hint".to_string(),
-                    json!(
-                        "If the original MCP HTTP session was lost, call close_idb(force=true) from a trusted recovery session."
-                    ),
-                );
-            }
-            None => {
-                map.insert("close_hint".to_string(), json!(self.close_hint()));
-            }
-        }
+        apply_close_metadata(map, grant, self.close_hint());
     }
 
     fn instructions(&self) -> String {
@@ -785,35 +745,62 @@ impl IdaMcpServer {
             if !frameworks.is_empty() {
                 map.insert("frameworks_loaded".to_string(), json!(frameworks));
             }
-            match close_token {
-                Some(Ok(grant)) => {
-                    map.insert(
-                        "close_owner_session_id".to_string(),
-                        json!(grant.owner_session_id),
-                    );
-                    map.insert("close_token".to_string(), json!(grant.token));
-                    if grant.reused {
-                        map.insert("close_token_reused".to_string(), json!(true));
-                    }
-                }
-                Some(Err(owner_session_id)) => {
-                    map.insert(
-                        "close_owner_session_id".to_string(),
-                        json!(owner_session_id),
-                    );
-                    map.insert(
-                        "close_recovery_hint".to_string(),
-                        json!(
-                            "If the original MCP HTTP session was lost, call close_idb(force=true) from a trusted recovery session."
-                        ),
-                    );
-                }
-                None => {}
-            }
+            apply_close_metadata(map, close_token, close_hint_for(mode));
         }
 
         info!(task_id = %task_id, "DSC background task completed");
         registry.complete(&task_id, value);
+    }
+}
+
+fn close_hint_for(mode: ServerMode) -> &'static str {
+    match mode {
+        ServerMode::Stdio => "Call close_idb when done to release locks for other sessions.",
+        ServerMode::Http => "In multi-client (HTTP/SSE) mode, close_idb accepts the close_token returned by open_idb. The owning session can also close without re-sending the token, and close_idb(force=true) can recover from a lost session.",
+    }
+}
+
+/// Insert close-ownership metadata onto a tool result, identical for foreground
+/// `open_idb` and the DSC background task so clients see one shape via both
+/// paths.
+fn apply_close_metadata(
+    map: &mut serde_json::Map<String, Value>,
+    grant: Option<Result<CloseTokenGrant, String>>,
+    close_hint: &str,
+) {
+    match grant {
+        Some(Ok(grant)) => {
+            map.insert("close_hint".to_string(), json!(close_hint));
+            map.insert(
+                "close_owner_session_id".to_string(),
+                json!(grant.owner_session_id),
+            );
+            map.insert("close_token".to_string(), json!(grant.token));
+            if grant.reused {
+                map.insert("close_token_reused".to_string(), json!(true));
+            }
+        }
+        Some(Err(owner_session_id)) => {
+            map.insert(
+                "close_hint".to_string(),
+                json!(format!(
+                    "The open database is currently owned by HTTP session {owner_session_id}. Reuse that session to call close_idb, or call close_idb(force=true) to recover if the owning session was lost."
+                )),
+            );
+            map.insert(
+                "close_owner_session_id".to_string(),
+                json!(owner_session_id),
+            );
+            map.insert(
+                "close_recovery_hint".to_string(),
+                json!(
+                    "If the original MCP HTTP session was lost, call close_idb(force=true) from a trusted recovery session."
+                ),
+            );
+        }
+        None => {
+            map.insert("close_hint".to_string(), json!(close_hint));
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up polish to #18 (review notes from https://github.com/blacktop/ida-mcp-rs/pull/18#issuecomment-4371877060).

## Summary
- Hoist `apply_close_metadata` to a free function so the DSC background task emits the same `close_hint` / `close_owner_session_id` / `close_token` shape as foreground `open_idb`. Previously `task_status` payloads omitted `close_hint` from DSC opens.
- Drop dead `Option<String>` wrappers in `CloseAuthorization::{GrantedByOverride, Denied}` — both fields were always `Some(...)` when constructed.
- Add unit tests for the token-from-other-session and no-lease-grants paths.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 71/71 pass (was 69, +2 new)