### PR TITLE
test: add HTTP close-ownership recovery coverage

### DIFF
--- a/justfile
+++ b/justfile
@@ -136,6 +136,10 @@ test: build
 test-http: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-http
 
+# Run HTTP close-ownership recovery test (issue #19, PRs #18 / #21)
+test-http-recovery: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-http-recovery
+
 # Run IDAPython script integration test (debug)
 test-script: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-script

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4183,7 +4183,9 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
 
 #[cfg(test)]
 mod tests {
+    use crate::ida::worker::CloseTokenGrant;
     use crate::server::{
+        apply_close_metadata, close_hint_for,
         operation::{OperationSnapshot, OperationStatus},
         run_script_failure_message, run_script_succeeded, run_script_timeout_message,
         run_script_truncate_chars, task_payload_result_value, IdaMcpServer,
@@ -4191,7 +4193,7 @@ mod tests {
     };
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
-    use serde_json::json;
+    use serde_json::{json, Value};
     use std::sync::{mpsc, Arc};
 
     fn test_server() -> IdaMcpServer {
@@ -4409,5 +4411,75 @@ mod tests {
         let file = std::fs::File::create(&path)?;
         file.set_len(len)?;
         Ok(path)
+    }
+
+    fn metadata_map(
+        grant: Option<Result<CloseTokenGrant, String>>,
+    ) -> serde_json::Map<String, Value> {
+        let mut map = serde_json::Map::new();
+        apply_close_metadata(&mut map, grant, close_hint_for(crate::ServerMode::Http));
+        map
+    }
+
+    #[test]
+    fn close_metadata_grant_emits_token_owner_and_hint() {
+        let map = metadata_map(Some(Ok(CloseTokenGrant {
+            token: "tok-1".into(),
+            reused: false,
+            owner_session_id: "session-a".into(),
+        })));
+        assert_eq!(
+            map.get("close_token").and_then(Value::as_str),
+            Some("tok-1")
+        );
+        assert_eq!(
+            map.get("close_owner_session_id").and_then(Value::as_str),
+            Some("session-a")
+        );
+        assert!(map.contains_key("close_hint"));
+        assert!(!map.contains_key("close_token_reused"));
+        assert!(!map.contains_key("close_recovery_hint"));
+    }
+
+    #[test]
+    fn close_metadata_marks_reused_grant() {
+        let map = metadata_map(Some(Ok(CloseTokenGrant {
+            token: "tok-2".into(),
+            reused: true,
+            owner_session_id: "session-a".into(),
+        })));
+        assert_eq!(
+            map.get("close_token_reused").and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn close_metadata_denial_emits_owner_recovery_hint_and_no_token() {
+        let map = metadata_map(Some(Err("session-original".into())));
+        assert!(!map.contains_key("close_token"));
+        assert_eq!(
+            map.get("close_owner_session_id").and_then(Value::as_str),
+            Some("session-original")
+        );
+        let recovery = map
+            .get("close_recovery_hint")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(recovery.contains("force=true"));
+        let hint = map
+            .get("close_hint")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(hint.contains("session-original"));
+    }
+
+    #[test]
+    fn close_metadata_none_emits_only_hint() {
+        let map = metadata_map(None);
+        assert!(map.contains_key("close_hint"));
+        assert!(!map.contains_key("close_token"));
+        assert!(!map.contains_key("close_owner_session_id"));
+        assert!(!map.contains_key("close_recovery_hint"));
     }
 }

--- a/test/http_close_recovery.sh
+++ b/test/http_close_recovery.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Verify HTTP close-ownership recovery (issue #19, PRs #18 / #21):
+# - owning HTTP session can call close_idb without a token
+# - a different HTTP session is denied with a structured response
+# - close_idb(force=true) recovers from a lost owner session
+# - --session-keep-alive-secs is accepted on the CLI
+set -euo pipefail
+
+PORT="${PORT:-8765}"
+BIN="${MCP_HTTP_BIN:-./target/release/ida-mcp}"
+ORIGIN="${MCP_HTTP_ORIGIN:-http://localhost}"
+ALLOW_ORIGIN="${MCP_HTTP_ALLOW_ORIGIN:-http://localhost,http://127.0.0.1}"
+BIND_HOST="${MCP_HTTP_BIND_HOST:-127.0.0.1}"
+CONNECT_HOST="${MCP_HTTP_CONNECT_HOST:-127.0.0.1}"
+IDB_PATH="${IDB_PATH:-fixtures/mini}"
+SESSION_KEEP_ALIVE="${SESSION_KEEP_ALIVE:-1800}"
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -x "$BIN" ]]; then
+  echo "missing server binary: $BIN" >&2
+  exit 1
+fi
+
+# CLI smoke: --session-keep-alive-secs must be present in serve-http --help
+"$BIN" serve-http --help 2>&1 | grep -q -- '--session-keep-alive-secs' || {
+  echo "serve-http --help missing --session-keep-alive-secs" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+server_log="$tmpdir/server.log"
+
+cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+curl_headers=(
+  -H "Content-Type: application/json"
+  -H "Accept: application/json, text/event-stream"
+  -H "Origin: $ORIGIN"
+)
+
+url="http://$CONNECT_HOST:$PORT/"
+
+"$BIN" serve-http \
+  --bind "$BIND_HOST:$PORT" \
+  --allow-origin "$ALLOW_ORIGIN" \
+  --session-keep-alive-secs "$SESSION_KEEP_ALIVE" \
+  >"$server_log" 2>&1 &
+server_pid=$!
+
+# init_session prints the Mcp-Session-Id of a fresh client to stdout.
+init_session() {
+  local headers="$tmpdir/init.h.$$"
+  local body="$tmpdir/init.b.$$"
+  local payload
+  payload=$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"recovery","version":"0.1"},"capabilities":{}}}')
+  for _ in {1..100}; do
+    if curl -sS -D "$headers" -o "$body" \
+      "${curl_headers[@]}" \
+      -d "$payload" \
+      "$url" >/dev/null 2>&1; then
+      local sid
+      sid="$(awk -F': ' 'tolower($1)=="mcp-session-id" {print $2}' "$headers" | tr -d '\r')"
+      if [[ -n "$sid" ]]; then
+        # complete the handshake
+        curl -sS "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+          -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+          "$url" >/dev/null
+        rm -f "$headers" "$body"
+        printf '%s' "$sid"
+        return 0
+      fi
+    fi
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  rm -f "$headers" "$body"
+  echo "failed to obtain Mcp-Session-Id" >&2
+  if [[ -s "$server_log" ]]; then
+    echo "server log:" >&2
+    cat "$server_log" >&2
+  fi
+  exit 1
+}
+
+# call <session-id> <id> <method> <params-json> -> raw response body
+call() {
+  local sid="$1" rid="$2" method="$3" params="$4"
+  curl -sS "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":${rid},\"method\":\"${method}\",\"params\":${params}}" \
+    "$url"
+}
+
+# tool_text <session-id> <id> <tool> <args-json> -> the tool's text payload
+tool_text() {
+  local sid="$1" rid="$2" tool="$3" args="$4"
+  local raw
+  raw=$(call "$sid" "$rid" "tools/call" \
+    "{\"name\":\"${tool}\",\"arguments\":${args}}")
+  # Accept both plain JSON (stateless) and SSE framing. Pull the first
+  # JSON object from either layout.
+  printf '%s\n' "$raw" \
+    | awk '/^\{/{print; exit} /^data: \{/{sub(/^data: /,""); print; exit}' \
+    | jq -r '.result.content[0].text // empty'
+}
+
+session_a="$(init_session)"
+echo "   session A: $session_a"
+
+# --- Phase 1: open_idb in session A, capture ownership metadata ---
+open_a=$(tool_text "$session_a" 10 open_idb \
+  "{\"path\":\"$IDB_PATH\"}")
+echo "$open_a" | jq -e '.function_count' >/dev/null || {
+  echo "open_idb (A) missing function_count" >&2
+  echo "$open_a" >&2
+  exit 1
+}
+close_token=$(echo "$open_a" | jq -r '.close_token')
+owner_id=$(echo "$open_a" | jq -r '.close_owner_session_id')
+[[ -n "$close_token" && "$close_token" != "null" ]] || { echo "close_token missing in open_idb response" >&2; exit 1; }
+[[ -n "$owner_id" && "$owner_id" != "null" ]] || { echo "close_owner_session_id missing" >&2; exit 1; }
+echo "   open_idb returned close_token + close_owner_session_id"
+
+# --- Phase 2: owning session closes WITHOUT the token (new shortcut) ---
+close_a_notoken=$(tool_text "$session_a" 11 close_idb "{}")
+echo "$close_a_notoken" | grep -qi "Database closed" || {
+  echo "owning session should close without token; got: $close_a_notoken" >&2
+  exit 1
+}
+echo "   owning session closed without token"
+
+# --- Phase 3: re-open in A, then start a fresh HTTP session B ---
+open_a2=$(tool_text "$session_a" 12 open_idb \
+  "{\"path\":\"$IDB_PATH\"}")
+owner_a2=$(echo "$open_a2" | jq -r '.close_owner_session_id')
+[[ "$owner_a2" == "$owner_id" ]] || {
+  echo "owner_session_id should be stable across reopens in same HTTP session" >&2
+  echo "  expected=$owner_id got=$owner_a2" >&2
+  exit 1
+}
+echo "   re-opened in A; owner_session_id stable"
+
+session_b="$(init_session)"
+echo "   session B: $session_b"
+[[ "$session_b" != "$session_a" ]] || { echo "session B Mcp-Session-Id collided with A" >&2; exit 1; }
+
+# --- Phase 4: session B without token/force gets structured denial ---
+deny_b=$(tool_text "$session_b" 20 close_idb "{}")
+echo "$deny_b" | jq -e '.closed == false' >/dev/null || {
+  echo "session B close should be denied with closed:false; got: $deny_b" >&2
+  exit 1
+}
+deny_owner=$(echo "$deny_b" | jq -r '.owner_session_id')
+[[ "$deny_owner" == "$owner_id" ]] || {
+  echo "denial owner_session_id should match A's; expected=$owner_id got=$deny_owner" >&2
+  exit 1
+}
+echo "$deny_b" | jq -e '.hint | contains("force=true")' >/dev/null || {
+  echo "denial hint should mention force=true; got: $deny_b" >&2
+  exit 1
+}
+echo "   session B denied with structured payload"
+
+# --- Phase 5: session B force=true overrides and closes ---
+force_b=$(tool_text "$session_b" 21 close_idb '{"force":true}')
+echo "$force_b" | grep -qi "Database closed" || {
+  echo "force=true close should succeed; got: $force_b" >&2
+  exit 1
+}
+echo "   force=true override closed the IDB"
+
+# --- Phase 6: ownership cleared — a third session can claim ---
+session_c="$(init_session)"
+open_c=$(tool_text "$session_c" 30 open_idb \
+  "{\"path\":\"$IDB_PATH\"}")
+new_owner=$(echo "$open_c" | jq -r '.close_owner_session_id')
+[[ -n "$new_owner" && "$new_owner" != "null" && "$new_owner" != "$owner_id" ]] || {
+  echo "after force-close, a new session should be able to claim a new ownership; got owner=$new_owner" >&2
+  exit 1
+}
+echo "   new session C claimed ownership after recovery"
+
+# Best-effort cleanup
+tool_text "$session_c" 31 close_idb '{"force":true}' >/dev/null || true
+
+echo "HTTP close-recovery test passed"

--- a/test/justfile
+++ b/test/justfile
@@ -136,6 +136,36 @@ test-http: fixture
         ./http_integration.sh
     echo "✅ HTTP test passed"
 
+# Run HTTP close-ownership recovery test (issue #19, PRs #18 / #21)
+test-http-recovery: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'cargo build --release' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for close-recovery test (brew install jq)"
+        exit 1
+    fi
+    LOCK="{{ test_lock }}"
+    if [ -f "$LOCK" ]; then
+        pid=$(awk -F= '$1=="pid"{print $2}' "$LOCK" | tr -d '\r')
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            echo "Lock file $LOCK is held by pid $pid; close that server first." >&2
+            exit 1
+        else
+            rm -f "$LOCK"
+        fi
+    fi
+    echo "🧪 Running HTTP close-ownership recovery test..."
+    PORT=$((9100 + RANDOM % 800)) \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        ./http_close_recovery.sh
+    echo "✅ HTTP close-recovery test passed"
+
 # Run IDAPython script integration test
 test-script: test-bootstrap
     #!/usr/bin/env bash


### PR DESCRIPTION
Closes the test-coverage gap for #19 / #18 / #21.

## What's covered
- **Unit (`src/server/mod.rs`)** — 4 tests for `apply_close_metadata`:
  - grant emits `close_token`, `close_owner_session_id`, `close_hint`
  - reused grant carries `close_token_reused: true`
  - denial emits owner + recovery hint and no token
  - stdio (no-grant) emits only `close_hint`
- **Integration (`test/http_close_recovery.sh` + `just test-http-recovery`)** — exercises against the live HTTP transport:
  1. `serve-http --help` accepts `--session-keep-alive-secs`
  2. `open_idb` returns `close_token` + `close_owner_session_id`
  3. owning HTTP session calls `close_idb` without a token (new shortcut)
  4. re-open keeps `close_owner_session_id` stable across opens
  5. a fresh HTTP session is denied with `closed: false` + structured `owner_session_id` and `hint` containing `force=true`
  6. `close_idb(force=true)` from the other session overrides and closes
  7. after recovery a third session can claim ownership

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` — 75/75 (was 71, +4 new)
- [x] `just test-http-recovery` on macOS arm64
- [ ] `just test-http-recovery` on Linux aarch64 VM
- [ ] `just test-http-recovery` on Windows x86_64 VM