### PR TITLE
test: add callees indirect-call regression for PR #20

### DIFF
--- a/justfile
+++ b/justfile
@@ -164,6 +164,10 @@ test-dsc dsc_path="": build
 test-crash-guard: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-crash-guard
 
+# Run callees-indirect regression test (PR #20: bundle-id naming + indirect-call operand filter)
+test-callees-indirect: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-callees-indirect
+
 # Run cargo unit tests
 cargo-test:
     RUST_BACKTRACE=1 cargo test

--- a/test/fixtures/indirect.c
+++ b/test/fixtures/indirect.c
@@ -1,0 +1,32 @@
+// Fixture for callees-fallback regression test (PR #20).
+//
+// `interesting_function` contains both:
+//   - a direct call to `direct_callee` (operand kind: Near)
+//   - an indirect call through `fptr` in BSS (operand kind: Mem/Displ
+//     depending on arch — neither encodes a callee address)
+//
+// callees(interesting_function) must include direct_callee and must NOT
+// include any address sourced from the indirect call's operand. The
+// pre-fix fallback in src/ida/handlers/controlflow.rs treated any
+// op.address() as a callee, which produced bogus nodes for Mem/Displ.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int direct_callee(int x) { return x * 2; }
+
+int (*fptr)(int);
+
+int interesting_function(int x) {
+    int a = direct_callee(x);
+    fptr = direct_callee;
+    int b = fptr(x);
+    return a + b;
+}
+
+int main(int argc, char **argv) {
+    fptr = direct_callee;
+    int n = argc > 1 ? atoi(argv[1]) : 5;
+    printf("%d\n", interesting_function(n));
+    return 0;
+}

--- a/test/http_close_recovery.sh
+++ b/test/http_close_recovery.sh
@@ -65,7 +65,7 @@ init_session() {
   local body="$tmpdir/init.b.$$"
   local payload
   payload=$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"recovery","version":"0.1"},"capabilities":{}}}')
-  for _ in {1..100}; do
+  for _ in {1..300}; do  # 30s upper bound — generous for Rosetta-emulated Windows VM
     if curl -sS -D "$headers" -o "$body" \
       "${curl_headers[@]}" \
       -d "$payload" \

--- a/test/justfile
+++ b/test/justfile
@@ -229,6 +229,31 @@ test-elicitation: fixture
     RUST_LOG="{{ rust_log }}" MCP_STDIO_BIN="{{ server_bin }}" bash ./stdio_elicitation.sh
     echo "✅ Elicitation test passed"
 
+# Run callees-indirect regression test (PR #20)
+# Builds a tiny C fixture with both a direct and an indirect call, opens it
+# at a bundle-id-style path, and checks that callees() returns only the direct
+# callee (no bogus entry from the indirect call's Mem/Displ operand).
+test-callees-indirect:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'cargo build --release' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for callees-indirect test (brew install jq)"
+        exit 1
+    fi
+    if ! command -v {{ cc }} >/dev/null 2>&1; then
+        echo "{{ cc }} is required to build the fixture"
+        exit 1
+    fi
+    echo "🧪 Running callees-indirect regression test..."
+    RUST_LOG="{{ rust_log }}" MCP_STDIO_BIN="{{ server_bin }}" CC="{{ cc }}" \
+        bash ./stdio_callees_indirect.sh
+    echo "✅ callees-indirect test passed"
+
 # Run crash-guard integration test
 # Verifies that SIGSEGV during a handler call is caught and converted to a
 # ToolError instead of killing the server. Triggers a real segfault via

--- a/test/stdio_callees_indirect.sh
+++ b/test/stdio_callees_indirect.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Regression test for PR #20's callees fallback (issue: indirect-call
+# operands like Mem/Displ also expose op.address(), so the unfiltered
+# fallback invented bogus callee nodes for `call qword ptr [rip+x]` and
+# similar). Verifies that:
+#   1. open_idb on a raw binary with a bundle-id-style filename produces
+#      the path with `.i64` appended (not replacing the trailing dotted
+#      segment) — covers PR #20's path-naming fix.
+#   2. callees() on a function with an indirect call returns the direct
+#      callee but not the indirect-call's load-site address — covers the
+#      operand-kind filter added in the PR #20 fixup.
+set -euo pipefail
+
+BIN="${MCP_STDIO_BIN:-../target/debug/ida-mcp}"
+FIXTURE_SRC="${FIXTURE_SRC:-fixtures/indirect.c}"
+CC_BIN="${CC:-cc}"
+
+# Use a bundle-id-style filename so this also exercises PR #20's path fix.
+work_dir="$(mktemp -d)"
+fixture="$work_dir/com.apple.driver.testfix"
+expected_i64="$fixture.i64"
+
+cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$work_dir"
+  if [[ -n "${fifo_in:-}" ]]; then
+    rm -f "$fifo_in"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+[[ -x "$BIN" ]] || { echo "missing $BIN" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+command -v "$CC_BIN" >/dev/null || { echo "$CC_BIN required to build fixture" >&2; exit 1; }
+
+"$CC_BIN" -O0 -g -fno-omit-frame-pointer -o "$fixture" "$FIXTURE_SRC"
+
+fifo_in="$(mktemp -u).fifo"
+mkfifo "$fifo_in"
+log="$work_dir/server.log"
+
+"$BIN" < "$fifo_in" > "$log" 2>&1 &
+server_pid=$!
+exec 3>"$fifo_in"
+
+send() { echo "$1" >&3; }
+
+wait_response() {
+  local target_id="$1" timeout="${2:-90}" elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    local line
+    line=$(grep -m1 "\"id\":${target_id}[,}]" "$log" 2>/dev/null | grep '"jsonrpc"' || true)
+    [[ -n "$line" ]] && { echo "$line"; return 0; }
+    sleep 1; elapsed=$((elapsed + 1))
+  done
+  echo "timeout id=$target_id" >&2
+  echo "--- server log ---" >&2; cat "$log" >&2
+  return 1
+}
+
+text() { jq -r '.result.content[0].text // empty'; }
+
+send '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"callees-indirect","version":"0.1"},"capabilities":{}}}'
+send '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+wait_response 1 10 >/dev/null
+echo "   initialized"
+
+# Phase 1: open the bundle-id-named raw binary
+payload=$(printf '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"open_idb","arguments":{"path":"%s","auto_analyse":true}}}' "$fixture")
+send "$payload"
+open_text=$(wait_response 2 120 | text)
+i64_path=$(echo "$open_text" | jq -r '.path // empty')
+
+[[ "$i64_path" == "$expected_i64" ]] || {
+  echo "FAIL: open_idb returned path '$i64_path', expected '$expected_i64'" >&2
+  echo "$open_text" >&2
+  exit 1
+}
+echo "   ✓ Bundle-id name preserved: $i64_path"
+
+# Phase 2: resolve the function and pull its callees
+send '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"resolve_function","arguments":{"name":"interesting_function"}}}'
+addr=$(wait_response 3 30 | text | jq -r '.address // empty')
+[[ -n "$addr" && "$addr" != "null" ]] || { echo "FAIL: resolve_function returned no address" >&2; exit 1; }
+echo "   interesting_function @ $addr"
+
+send "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"callees\",\"arguments\":{\"addr\":\"$addr\"}}}"
+callees_text=$(wait_response 4 30 | text)
+
+# Must include direct_callee
+echo "$callees_text" | jq -e '.[] | select(.name | test("direct_callee"))' >/dev/null || {
+  echo "FAIL: callees missing direct_callee" >&2
+  echo "$callees_text" >&2
+  exit 1
+}
+echo "   ✓ direct_callee present"
+
+# Must NOT contain any callee whose address belongs to the same fixture's
+# data segment (i.e. the BSS slot that holds `fptr`). We approximate this
+# by rejecting any callee with size==0 AND a name that doesn't start with
+# `direct_callee` or known function naming. The pre-fix fallback would
+# have produced an entry with size==0 pointing at the fptr load address.
+bogus=$(echo "$callees_text" | jq -r '
+  .[] | select(.name | test("direct_callee") | not) | .address
+')
+if [[ -n "$bogus" ]]; then
+  echo "FAIL: callees included unexpected non-direct-callee entries:" >&2
+  echo "$bogus" | sed 's/^/  /' >&2
+  echo "full callees response:" >&2
+  echo "$callees_text" >&2
+  exit 1
+fi
+echo "   ✓ No bogus callee from indirect call"
+
+# Phase 3: clean close so .i64 is flushed
+send '{"jsonrpc":"2.0","id":99,"method":"tools/call","params":{"name":"close_idb","arguments":{}}}'
+wait_response 99 10 >/dev/null
+
+[[ -f "$expected_i64" ]] || { echo "FAIL: $expected_i64 not on disk after close" >&2; exit 1; }
+echo "   ✓ .i64 flushed at expected path"
+
+echo "✅ callees-indirect regression passed"


### PR DESCRIPTION
Lifts the manual E2E verify of PR #20 into a permanent `just test-callees-indirect` recipe. See commit message for details.