### PR TITLE
test: add just measure-tools recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -168,6 +168,10 @@ test-crash-guard: build
 test-callees-indirect: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-callees-indirect
 
+# Measure the tools/list payload size (per-tool char ranking + descriptions/schemas split)
+measure-tools: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp just measure-tools
+
 # Run cargo unit tests
 cargo-test:
     RUST_BACKTRACE=1 cargo test

--- a/test/justfile
+++ b/test/justfile
@@ -254,6 +254,25 @@ test-callees-indirect:
         bash ./stdio_callees_indirect.sh
     echo "✅ callees-indirect test passed"
 
+# Measure tools/list payload size; useful for regression-watching
+# tool description bloat (issue: #11364). Set FAIL_OVER_CHARS=N to fail
+# the recipe when the total exceeds N (CI guard); leave unset to just print.
+measure-tools:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required (brew install jq)"
+        exit 1
+    fi
+    BIN="{{ server_bin }}" TOP="${TOP:-10}" \
+        FAIL_OVER_CHARS="${FAIL_OVER_CHARS:-0}" \
+        bash ./measure_tools.sh
+
 # Run crash-guard integration test
 # Verifies that SIGSEGV during a handler call is caught and converted to a
 # ToolError instead of killing the server. Triggers a real segfault via

--- a/test/measure_tools.sh
+++ b/test/measure_tools.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Measure the tools/list payload that Claude Code (and other MCP clients)
+# load into context every session. Drives ida-mcp via stdio, captures the
+# tools/list response, and reports a per-tool ranking by JSON char count.
+#
+# Char count is deterministic and CI-friendly. For an exact token count,
+# pipe the captured tools array through Anthropic count_tokens or your
+# tokenizer of choice.
+#
+# Usage:
+#   just measure-tools                # via the just recipe
+#   BIN=./target/release/ida-mcp ./test/measure_tools.sh
+#   TOP=20 ./test/measure_tools.sh    # show top 20 tools (default 10)
+#   FAIL_OVER_CHARS=50000 ./test/measure_tools.sh   # CI guard
+set -euo pipefail
+
+BIN="${BIN:-../target/debug/ida-mcp}"
+TOP="${TOP:-10}"
+FAIL_OVER_CHARS="${FAIL_OVER_CHARS:-0}"  # 0 = no guard
+
+[[ -x "$BIN" ]] || { echo "missing $BIN" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq required" >&2; exit 1; }
+
+fifo="$(mktemp -u).fifo"
+mkfifo "$fifo"
+log="$(mktemp)"
+
+cleanup() {
+  exec 3>&- 2>/dev/null || true
+  rm -f "$fifo" "$log"
+  if [[ -n "${pid:-}" ]]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+"$BIN" < "$fifo" > "$log" 2>&1 &
+pid=$!
+exec 3>"$fifo"
+
+send() { echo "$1" >&3; }
+
+send '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"measure","version":"0.1"},"capabilities":{}}}'
+send '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+
+# Wait for initialize response
+for _ in {1..30}; do
+  grep -m1 '"id":1[,}]' "$log" 2>/dev/null | grep -q '"jsonrpc"' && break
+  sleep 1
+done
+
+send '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+resp=""
+for _ in {1..30}; do
+  resp=$(grep -m1 '"id":2[,}]' "$log" 2>/dev/null | grep '"jsonrpc"' || true)
+  [[ -n "$resp" ]] && break
+  sleep 1
+done
+
+[[ -n "$resp" ]] || { echo "no tools/list response" >&2; cat "$log" >&2; exit 1; }
+
+tools_json=$(echo "$resp" | jq '.result.tools')
+total_chars=$(echo "$tools_json" | jq -c '.' | wc -c | tr -d ' ')
+total_tools=$(echo "$tools_json" | jq 'length')
+desc_chars=$(echo "$tools_json" | jq -r '[.[] | .description // ""] | join("")' | wc -c | tr -d ' ')
+schema_chars=$(echo "$tools_json" | jq -c '[.[] | .inputSchema]' | wc -c | tr -d ' ')
+
+echo "── tools/list payload ──"
+printf "  tools:                %d\n" "$total_tools"
+printf "  total JSON:           %s chars\n" "$total_chars"
+printf "  └ descriptions:       %s chars\n" "$desc_chars"
+printf "  └ schemas (combined): %s chars\n" "$schema_chars"
+printf "  ~tokens (chars/4):    %d\n" "$((total_chars / 4))"
+echo
+
+echo "── top $TOP tools by chars ──"
+echo "$tools_json" | jq -r '
+  . as $t
+  | range(0; length) as $i
+  | "\($t[$i] | tojson | length)\t\($t[$i].name)"
+' | sort -rn | head -n "$TOP" | awk '{printf "  %5d  %s\n", $1, $2}'
+
+if (( FAIL_OVER_CHARS > 0 )) && (( total_chars > FAIL_OVER_CHARS )); then
+  echo
+  echo "FAIL: total $total_chars chars exceeds threshold $FAIL_OVER_CHARS" >&2
+  exit 1
+fi


### PR DESCRIPTION
Phase 2 step 1: baseline-tracking recipe for tools/list footprint. Network-free; FAIL_OVER_CHARS env var enables CI use as a regression guard.