### PR TITLE
refactor: extract TaskEntry state transitions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use ida_mcp::server::http_access::{HttpAccessPolicy, HttpAccessService};
 use ida_mcp::server::http_config::{
     build_session_manager, build_streamable_config, HttpServerOptions,
 };
+use ida_mcp::server::task::TaskRegistry;
 use ida_mcp::server::tool_filter::ToolFilter;
 use ida_mcp::server::SanitizedIdaServer;
 use ida_mcp::{
@@ -238,7 +239,7 @@ fn init_stdio_ida_state() -> anyhow::Result<ida::IdaInitState> {
     }
 }
 
-fn cancel_background_tasks(registry: &ida_mcp::server::task::TaskRegistry, message: &'static str) {
+fn cancel_background_tasks(registry: &TaskRegistry, message: &str) {
     let cancelled = registry.cancel_all_running(message);
     if cancelled > 0 {
         info!(
@@ -274,7 +275,7 @@ fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
                 ServerMode::Stdio,
                 filter_for_server.clone(),
             );
-            let task_registry = server.task_registry();
+            let task_registry = server.task_registry().clone();
             let sanitized = SanitizedIdaServer::with_filter(server, filter_for_server);
             let mut service = Some(sanitized.serve(stdio()).await?);
             let shutdown_notify = Arc::new(Notify::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::sync::Notify;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 const REQUEST_QUEUE_CAPACITY: usize = 64;
@@ -238,6 +238,16 @@ fn init_stdio_ida_state() -> anyhow::Result<ida::IdaInitState> {
     }
 }
 
+fn cancel_background_tasks(registry: &ida_mcp::server::task::TaskRegistry, message: &'static str) {
+    let cancelled = registry.cancel_all_running(message);
+    if cancelled > 0 {
+        info!(
+            cancelled_tasks = cancelled,
+            message, "Cancelled background tasks"
+        );
+    }
+}
+
 fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
     info!("Starting IDA MCP Server (server mode)");
     let init_state = init_stdio_ida_state()?;
@@ -264,17 +274,20 @@ fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
                 ServerMode::Stdio,
                 filter_for_server.clone(),
             );
+            let task_registry = server.task_registry();
             let sanitized = SanitizedIdaServer::with_filter(server, filter_for_server);
             let mut service = Some(sanitized.serve(stdio()).await?);
             let shutdown_notify = Arc::new(Notify::new());
             let shutdown_signal = shutdown_notify.clone();
 
-            let shutdown_worker = worker_for_shutdown.clone();
+            let shutdown_tasks = task_registry.clone();
             tokio::spawn(async move {
                 if wait_for_shutdown_signal().await.is_ok() {
                     info!("Shutdown signal received");
-                    let _ = shutdown_worker.close_for_shutdown().await;
-                    let _ = shutdown_worker.shutdown().await;
+                    cancel_background_tasks(
+                        &shutdown_tasks,
+                        "Cancelled by server shutdown",
+                    );
                     shutdown_signal.notify_one();
                 } else {
                     info!("Shutdown signal handler failed; server will continue running");
@@ -284,6 +297,10 @@ fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
             loop {
                 tokio::select! {
                     _ = shutdown_notify.notified() => {
+                        cancel_background_tasks(
+                            &task_registry,
+                            "Cancelled by server shutdown",
+                        );
                         if let Some(mut running) = service.take() {
                             let _ = running.close().await?;
                         }
@@ -292,8 +309,20 @@ fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
                     _ = tokio::time::sleep(Duration::from_millis(200)) => {
                         if let Some(running) = service.as_ref() {
                             if running.is_transport_closed() {
-                                if let Some(running) = service.take() {
-                                    let _ = running.waiting().await?;
+                                cancel_background_tasks(
+                                    &task_registry,
+                                    "Cancelled by client disconnect",
+                                );
+                                if let Some(mut running) = service.take() {
+                                    if running
+                                        .close_with_timeout(Duration::from_secs(2))
+                                        .await?
+                                        .is_none()
+                                    {
+                                        warn!(
+                                            "Timed out waiting for stdio transport cleanup after client disconnect"
+                                        );
+                                    }
                                 }
                                 break;
                             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,8 +158,8 @@ impl IdaMcpServer {
         &self.filter
     }
 
-    pub fn task_registry(&self) -> task::TaskRegistry {
-        self.task_registry.clone()
+    pub fn task_registry(&self) -> &task::TaskRegistry {
+        &self.task_registry
     }
 
     fn close_hint(&self) -> &'static str {
@@ -3052,8 +3052,8 @@ impl IdaMcpServer {
         let registry = self.task_registry.clone();
         let worker = Arc::clone(&self.worker);
         let tid = task_id.clone();
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let worker_cancel = cancel.clone();
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let worker_cancel_token = cancel_token.clone();
 
         let handle = tokio::spawn(async move {
             // Bridge worker progress updates → task registry messages.
@@ -3069,7 +3069,7 @@ impl IdaMcpServer {
             });
 
             match worker
-                .analyze_funcs_observed(Some(tx), Some(worker_cancel))
+                .analyze_funcs_observed(Some(tx), Some(worker_cancel_token))
                 .await
             {
                 Ok(value) => {
@@ -3083,7 +3083,7 @@ impl IdaMcpServer {
             }
         });
         self.task_registry
-            .set_handle_with_cancel(&task_id, handle, cancel);
+            .set_handle_with_cancel_token(&task_id, handle, cancel_token);
         Ok(task_id)
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,6 +158,10 @@ impl IdaMcpServer {
         &self.filter
     }
 
+    pub fn task_registry(&self) -> task::TaskRegistry {
+        self.task_registry.clone()
+    }
+
     fn close_hint(&self) -> &'static str {
         close_hint_for(self.mode)
     }
@@ -3048,6 +3052,8 @@ impl IdaMcpServer {
         let registry = self.task_registry.clone();
         let worker = Arc::clone(&self.worker);
         let tid = task_id.clone();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let worker_cancel = cancel.clone();
 
         let handle = tokio::spawn(async move {
             // Bridge worker progress updates → task registry messages.
@@ -3062,7 +3068,10 @@ impl IdaMcpServer {
                 }
             });
 
-            match worker.analyze_funcs_observed(Some(tx), None).await {
+            match worker
+                .analyze_funcs_observed(Some(tx), Some(worker_cancel))
+                .await
+            {
                 Ok(value) => {
                     info!(task_id = %tid, "Background auto-analysis completed");
                     registry.complete(&tid, value);
@@ -3073,7 +3082,8 @@ impl IdaMcpServer {
                 }
             }
         });
-        self.task_registry.set_handle(&task_id, handle);
+        self.task_registry
+            .set_handle_with_cancel(&task_id, handle, cancel);
         Ok(task_id)
     }
 

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 pub const TERMINAL_TASK_CAP: usize = 256;
 /// `ttl` value exposed via MCP task metadata.
@@ -46,6 +47,7 @@ pub struct TaskState {
 struct TaskEntry {
     state: TaskState,
     handle: Option<JoinHandle<()>>,
+    cancel: Option<CancellationToken>,
 }
 
 /// Thread-safe registry of background tasks.
@@ -101,6 +103,7 @@ impl TaskRegistry {
             TaskEntry {
                 state,
                 handle: None,
+                cancel: None,
             },
         );
         prune_terminal_tasks(&mut entries);
@@ -131,6 +134,7 @@ impl TaskRegistry {
             TaskEntry {
                 state,
                 handle: None,
+                cancel: None,
             },
         );
         prune_terminal_tasks(&mut entries);
@@ -142,6 +146,21 @@ impl TaskRegistry {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = entries.get_mut(id) {
             entry.handle = Some(handle);
+            entry.cancel = None;
+        }
+    }
+
+    /// Store the `JoinHandle` and cancellation token for a task.
+    pub fn set_handle_with_cancel(
+        &self,
+        id: &str,
+        handle: JoinHandle<()>,
+        cancel: CancellationToken,
+    ) {
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(entry) = entries.get_mut(id) {
+            entry.handle = Some(handle);
+            entry.cancel = Some(cancel);
         }
     }
 
@@ -175,6 +194,7 @@ impl TaskRegistry {
             entry.state.result = Some(result);
             refresh_updated(&mut entry.state);
             entry.handle = None;
+            entry.cancel = None;
         }
         prune_terminal_tasks(&mut entries);
     }
@@ -187,6 +207,7 @@ impl TaskRegistry {
             entry.state.message = error.to_string();
             refresh_updated(&mut entry.state);
             entry.handle = None;
+            entry.cancel = None;
         }
         prune_terminal_tasks(&mut entries);
     }
@@ -197,6 +218,9 @@ impl TaskRegistry {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = entries.get_mut(id) {
             if entry.state.status == TaskStatus::Running {
+                if let Some(cancel) = entry.cancel.take() {
+                    cancel.cancel();
+                }
                 if let Some(handle) = entry.handle.take() {
                     handle.abort();
                 }
@@ -208,6 +232,34 @@ impl TaskRegistry {
             }
         }
         false
+    }
+
+    /// Cancel every currently running task. Returns the number of tasks marked
+    /// as cancelled.
+    pub fn cancel_all_running(&self, message: &str) -> usize {
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut cancelled = 0;
+
+        for entry in entries.values_mut() {
+            if entry.state.status == TaskStatus::Running {
+                if let Some(cancel) = entry.cancel.take() {
+                    cancel.cancel();
+                }
+                if let Some(handle) = entry.handle.take() {
+                    handle.abort();
+                }
+                entry.state.status = TaskStatus::Cancelled;
+                entry.state.message = message.to_string();
+                refresh_updated(&mut entry.state);
+                cancelled += 1;
+            }
+        }
+
+        if cancelled > 0 {
+            prune_terminal_tasks(&mut entries);
+        }
+
+        cancelled
     }
 }
 
@@ -290,6 +342,7 @@ mod tests {
     use crate::server::task::{TaskRegistry, TaskStatus, TERMINAL_TASK_CAP};
     use serde_json::json;
     use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
     #[test]
     fn create_and_get() {
@@ -376,6 +429,61 @@ mod tests {
 
         // Cancelling again returns false.
         assert!(!registry.cancel(&id));
+    }
+
+    #[tokio::test]
+    async fn cancel_running_task_signals_cancellation_token() {
+        let registry = TaskRegistry::new();
+        let id = registry
+            .create_keyed("t", "k-cancel", "Working")
+            .expect("should succeed");
+        let cancel = CancellationToken::new();
+        let observed = cancel.clone();
+        let handle = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        registry.set_handle_with_cancel(&id, handle, cancel);
+
+        assert!(registry.cancel(&id));
+        assert!(observed.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancel_all_running_cancels_tokens_and_preserves_terminal_tasks() {
+        let registry = TaskRegistry::new();
+        let id1 = registry
+            .create_keyed("t", "k-all-1", "Working 1")
+            .expect("should succeed");
+        let id2 = registry
+            .create_keyed("t", "k-all-2", "Working 2")
+            .expect("should succeed");
+        let completed = registry.create_completed("Done", json!({"ok": true}));
+
+        let cancel1 = CancellationToken::new();
+        let cancel2 = CancellationToken::new();
+        let observed1 = cancel1.clone();
+        let observed2 = cancel2.clone();
+        let handle1 = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        let handle2 = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        registry.set_handle_with_cancel(&id1, handle1, cancel1);
+        registry.set_handle_with_cancel(&id2, handle2, cancel2);
+
+        assert_eq!(registry.cancel_all_running("Cancelled by shutdown"), 2);
+        assert!(observed1.is_cancelled());
+        assert!(observed2.is_cancelled());
+
+        let state1 = registry.get(&id1).expect("task should exist");
+        let state2 = registry.get(&id2).expect("task should exist");
+        let completed_state = registry.get(&completed).expect("task should exist");
+        assert_eq!(state1.status, TaskStatus::Cancelled);
+        assert_eq!(state1.message, "Cancelled by shutdown");
+        assert_eq!(state2.status, TaskStatus::Cancelled);
+        assert_eq!(completed_state.status, TaskStatus::Completed);
+        assert_eq!(registry.cancel_all_running("again"), 0);
     }
 
     #[test]

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -47,7 +47,73 @@ pub struct TaskState {
 struct TaskEntry {
     state: TaskState,
     handle: Option<JoinHandle<()>>,
-    cancel: Option<CancellationToken>,
+    cancel_token: Option<CancellationToken>,
+}
+
+impl TaskEntry {
+    fn new(state: TaskState) -> Self {
+        Self {
+            state,
+            handle: None,
+            cancel_token: None,
+        }
+    }
+
+    fn set_handle(&mut self, handle: JoinHandle<()>, cancel_token: Option<CancellationToken>) {
+        self.handle = Some(handle);
+        self.cancel_token = cancel_token;
+    }
+
+    fn clear_runtime(&mut self) {
+        self.handle = None;
+        self.cancel_token = None;
+    }
+
+    fn abort_runtime(&mut self) {
+        if let Some(cancel_token) = self.cancel_token.take() {
+            cancel_token.cancel();
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+
+    fn complete(&mut self, result: Value) -> bool {
+        if self.state.status != TaskStatus::Running {
+            return false;
+        }
+
+        self.state.status = TaskStatus::Completed;
+        self.state.message = "Completed".to_string();
+        self.state.result = Some(result);
+        refresh_updated(&mut self.state);
+        self.clear_runtime();
+        true
+    }
+
+    fn fail(&mut self, error: &str) -> bool {
+        if self.state.status != TaskStatus::Running {
+            return false;
+        }
+
+        self.state.status = TaskStatus::Failed;
+        self.state.message = error.to_string();
+        refresh_updated(&mut self.state);
+        self.clear_runtime();
+        true
+    }
+
+    fn mark_cancelled(&mut self, message: &str) -> bool {
+        if self.state.status != TaskStatus::Running {
+            return false;
+        }
+
+        self.abort_runtime();
+        self.state.status = TaskStatus::Cancelled;
+        self.state.message = message.to_string();
+        refresh_updated(&mut self.state);
+        true
+    }
 }
 
 /// Thread-safe registry of background tasks.
@@ -98,14 +164,7 @@ impl TaskRegistry {
             updated_at_iso: created,
             key: Some(key.to_string()),
         };
-        entries.insert(
-            id.clone(),
-            TaskEntry {
-                state,
-                handle: None,
-                cancel: None,
-            },
-        );
+        entries.insert(id.clone(), TaskEntry::new(state));
         prune_terminal_tasks(&mut entries);
         Ok(id)
     }
@@ -129,14 +188,7 @@ impl TaskRegistry {
             updated_at_iso: created,
             key: None,
         };
-        entries.insert(
-            id.clone(),
-            TaskEntry {
-                state,
-                handle: None,
-                cancel: None,
-            },
-        );
+        entries.insert(id.clone(), TaskEntry::new(state));
         prune_terminal_tasks(&mut entries);
         id
     }
@@ -145,22 +197,20 @@ impl TaskRegistry {
     pub fn set_handle(&self, id: &str, handle: JoinHandle<()>) {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = entries.get_mut(id) {
-            entry.handle = Some(handle);
-            entry.cancel = None;
+            entry.set_handle(handle, None);
         }
     }
 
     /// Store the `JoinHandle` and cancellation token for a task.
-    pub fn set_handle_with_cancel(
+    pub fn set_handle_with_cancel_token(
         &self,
         id: &str,
         handle: JoinHandle<()>,
-        cancel: CancellationToken,
+        cancel_token: CancellationToken,
     ) {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = entries.get_mut(id) {
-            entry.handle = Some(handle);
-            entry.cancel = Some(cancel);
+            entry.set_handle(handle, Some(cancel_token));
         }
     }
 
@@ -188,72 +238,48 @@ impl TaskRegistry {
     /// Mark a task as completed with a JSON result.
     pub fn complete(&self, id: &str, result: Value) {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(entry) = entries.get_mut(id) {
-            entry.state.status = TaskStatus::Completed;
-            entry.state.message = "Completed".to_string();
-            entry.state.result = Some(result);
-            refresh_updated(&mut entry.state);
-            entry.handle = None;
-            entry.cancel = None;
+        let completed = match entries.get_mut(id) {
+            Some(entry) => entry.complete(result),
+            None => false,
+        };
+        if completed {
+            prune_terminal_tasks(&mut entries);
         }
-        prune_terminal_tasks(&mut entries);
     }
 
     /// Mark a task as failed with an error message.
     pub fn fail(&self, id: &str, error: &str) {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(entry) = entries.get_mut(id) {
-            entry.state.status = TaskStatus::Failed;
-            entry.state.message = error.to_string();
-            refresh_updated(&mut entry.state);
-            entry.handle = None;
-            entry.cancel = None;
+        let failed = match entries.get_mut(id) {
+            Some(entry) => entry.fail(error),
+            None => false,
+        };
+        if failed {
+            prune_terminal_tasks(&mut entries);
         }
-        prune_terminal_tasks(&mut entries);
     }
 
     /// Cancel a running task. Returns `true` if the task was running
     /// and has been aborted.
     pub fn cancel(&self, id: &str) -> bool {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(entry) = entries.get_mut(id) {
-            if entry.state.status == TaskStatus::Running {
-                if let Some(cancel) = entry.cancel.take() {
-                    cancel.cancel();
-                }
-                if let Some(handle) = entry.handle.take() {
-                    handle.abort();
-                }
-                entry.state.status = TaskStatus::Cancelled;
-                entry.state.message = "Cancelled by client".to_string();
-                refresh_updated(&mut entry.state);
-                prune_terminal_tasks(&mut entries);
-                return true;
-            }
+        let cancelled = match entries.get_mut(id) {
+            Some(entry) => entry.mark_cancelled("Cancelled by client"),
+            None => false,
+        };
+        if cancelled {
+            prune_terminal_tasks(&mut entries);
         }
-        false
+        cancelled
     }
 
     /// Cancel every currently running task. Returns the number of tasks marked
     /// as cancelled.
     pub fn cancel_all_running(&self, message: &str) -> usize {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        let mut cancelled = 0;
-
-        for entry in entries.values_mut() {
-            if entry.state.status == TaskStatus::Running {
-                if let Some(cancel) = entry.cancel.take() {
-                    cancel.cancel();
-                }
-                if let Some(handle) = entry.handle.take() {
-                    handle.abort();
-                }
-                entry.state.status = TaskStatus::Cancelled;
-                entry.state.message = message.to_string();
-                refresh_updated(&mut entry.state);
-                cancelled += 1;
-            }
-        }
+        let cancelled = entries.values_mut().fold(0, |count, entry| {
+            count + usize::from(entry.mark_cancelled(message))
+        });
 
         if cancelled > 0 {
             prune_terminal_tasks(&mut entries);
@@ -431,18 +457,35 @@ mod tests {
         assert!(!registry.cancel(&id));
     }
 
+    #[test]
+    fn terminal_tasks_ignore_late_complete_or_fail_updates() {
+        let registry = TaskRegistry::new();
+        let id = registry
+            .create_keyed("t", "late", "Working")
+            .expect("should succeed");
+
+        assert!(registry.cancel(&id));
+        registry.complete(&id, json!({"ok": true}));
+        registry.fail(&id, "late failure");
+
+        let state = registry.get(&id).expect("task should exist");
+        assert_eq!(state.status, TaskStatus::Cancelled);
+        assert_eq!(state.message, "Cancelled by client");
+        assert!(state.result.is_none());
+    }
+
     #[tokio::test]
     async fn cancel_running_task_signals_cancellation_token() {
         let registry = TaskRegistry::new();
         let id = registry
             .create_keyed("t", "k-cancel", "Working")
             .expect("should succeed");
-        let cancel = CancellationToken::new();
-        let observed = cancel.clone();
+        let cancel_token = CancellationToken::new();
+        let observed = cancel_token.clone();
         let handle = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
-        registry.set_handle_with_cancel(&id, handle, cancel);
+        registry.set_handle_with_cancel_token(&id, handle, cancel_token);
 
         assert!(registry.cancel(&id));
         assert!(observed.is_cancelled());
@@ -459,18 +502,18 @@ mod tests {
             .expect("should succeed");
         let completed = registry.create_completed("Done", json!({"ok": true}));
 
-        let cancel1 = CancellationToken::new();
-        let cancel2 = CancellationToken::new();
-        let observed1 = cancel1.clone();
-        let observed2 = cancel2.clone();
+        let cancel_token1 = CancellationToken::new();
+        let cancel_token2 = CancellationToken::new();
+        let observed1 = cancel_token1.clone();
+        let observed2 = cancel_token2.clone();
         let handle1 = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
         let handle2 = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
-        registry.set_handle_with_cancel(&id1, handle1, cancel1);
-        registry.set_handle_with_cancel(&id2, handle2, cancel2);
+        registry.set_handle_with_cancel_token(&id1, handle1, cancel_token1);
+        registry.set_handle_with_cancel_token(&id2, handle2, cancel_token2);
 
         assert_eq!(registry.cancel_all_running("Cancelled by shutdown"), 2);
         assert!(observed1.is_cancelled());


### PR DESCRIPTION
Encapsulates per-entry mutations behind methods. No behavior change. Follow-up to #33.