### PR TITLE
Add HTTP worker pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +980,7 @@ dependencies = [
  "bytes",
  "cc",
  "clap",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1280,6 +1287,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1418,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1528,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rand",
  "rmcp-macros",
  "schemars",
@@ -2178,6 +2212,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2243,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2217,6 +2283,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2268,6 +2344,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,8 +1002,8 @@ dependencies = [
 
 [[package]]
 name = "idalib"
-version = "0.7.3+9.3.260213"
-source = "git+https://github.com/blacktop/idalib.git?branch=sdk-9.3.1#ef76060b6b962b0fe39ae0c2c1d9194191f53766"
+version = "0.7.4+9.3.260213"
+source = "git+https://github.com/blacktop/idalib.git?branch=sdk-9.3.1#a286cd21857c45837766dac3ff2a3664216c3047"
 dependencies = [
  "anyhow",
  "autocxx",
@@ -1016,8 +1016,8 @@ dependencies = [
 
 [[package]]
 name = "idalib-build"
-version = "0.7.3+9.3.260213"
-source = "git+https://github.com/blacktop/idalib.git?branch=sdk-9.3.1#ef76060b6b962b0fe39ae0c2c1d9194191f53766"
+version = "0.7.4+9.3.260213"
+source = "git+https://github.com/blacktop/idalib.git?branch=sdk-9.3.1#a286cd21857c45837766dac3ff2a3664216c3047"
 dependencies = [
  "anyhow",
  "idalib-sys",
@@ -1025,8 +1025,8 @@ dependencies = [
 
 [[package]]
 name = "idalib-sys"
-version = "0.7.3+9.3.260213"
-source = "git+https://github.com/blacktop/idalib.git?branch=sdk-9.3.1#ef76060b6b962b0fe39ae0c2c1d9194191f53766"
+version = "0.7.4+9.3.260213"
+source = "git+https://github.com/blacktop/idalib.git?branch=sdk-9.3.1#a286cd21857c45837766dac3ff2a3664216c3047"
 dependencies = [
  "anyhow",
  "autocxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["development-tools", "command-line-utilities"]
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 idalib = { git = "https://github.com/blacktop/idalib.git", branch = "sdk-9.3.1" }
-rmcp = { version = "1.6", features = ["server", "transport-io", "transport-streamable-http-server", "elicitation", "schemars"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "signal"] }
+rmcp = { version = "1.6", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "schemars"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "signal", "process", "io-util"] }
 tokio-util = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -25,6 +25,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive", "env"] }
 libc = "0.2"
 bytes = "1"
+futures-util = "0.3"
 http = "1"
 http-body = "1"
 http-body-util = "0.1"

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ If an SSE-capable client exits without sending `close_idb` or HTTP `DELETE`,
 pooled mode closes the session after its standalone SSE stream disconnects and
 the `--worker-disconnect-grace-secs` reconnect grace elapses.
 POST-only clients do not always leave a stream for the server to observe, so
-their orphaned sessions are reclaimed by `--session-keep-alive-secs`, which
-defaults to 300 seconds in pooled mode and 1800 seconds in legacy HTTP mode.
+their orphaned sessions are reclaimed by `--session-keep-alive-secs` (default
+1800 seconds). Lower it if you need faster pool reclaim for POST-only clients.
 
 #### `dyld_shared_cache` analysis
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,36 @@ decompile(address: "0x100000f00")
 tool_catalog(query: "find callers")
 ```
 
+#### HTTP/SSE worker pool
+
+`serve-http` keeps the existing single in-process IDA worker by default. For
+stateful multi-client HTTP/SSE usage, set `--max-workers` above `1` to route
+sessions through child `ida-mcp worker` processes:
+
+```bash
+ida-mcp serve-http --bind 127.0.0.1:8765 --max-workers 4 --min-workers 1
+```
+
+Without `--max-workers N`, HTTP sessions still share one IDA context; a second
+client opening another binary waits behind the first and then gets the normal
+`A database is already open` error. Pooled startup logs include
+`Starting pooled HTTP router` and `MCP pooled HTTP server listening`.
+
+Each opened HTTP session leases one child worker until `close_idb`, HTTP
+`DELETE`, session timeout, or server shutdown. `close_idb` releases the lease
+immediately, but the child process may stay alive idle for reuse until
+`--worker-idle-timeout-secs` elapses. If all workers are leased, new
+`open_idb`/`open_dsc` calls fail with `Worker pool exhausted` so clients can
+retry later. Pooled mode requires stateful HTTP sessions; `--max-workers > 1`
+is rejected with `--stateless`.
+
+If an SSE-capable client exits without sending `close_idb` or HTTP `DELETE`,
+pooled mode closes the session after its standalone SSE stream disconnects and
+the `--worker-disconnect-grace-secs` reconnect grace elapses.
+POST-only clients do not always leave a stream for the server to observe, so
+their orphaned sessions are reclaimed by `--session-keep-alive-secs`, which
+defaults to 300 seconds in pooled mode and 1800 seconds in legacy HTTP mode.
+
 #### `dyld_shared_cache` analysis
 
 `open_dsc` opens a single module from Apple's dyld_shared_cache. On first use it runs `idat` in the background to create the `.i64` (this can take minutes). Subsequent opens are instant.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -105,8 +105,11 @@ On Linux and Windows, users may need to set environment variables at runtime:
 # Stdio (default, single-client)
 ./target/release/ida-mcp
 
-# Streamable HTTP (multi-client, SSE)
+# Streamable HTTP (multi-client transport, one IDB by default)
 ./target/release/ida-mcp serve-http --bind 127.0.0.1:8765
+
+# Streamable HTTP with concurrent multi-IDB worker pool
+./target/release/ida-mcp serve-http --bind 127.0.0.1:8765 --max-workers 4 --min-workers 1
 
 # CLI probe (test IDA connection)
 ./target/release/ida-mcp probe --path /path/to/binary --list 10

--- a/docs/TRANSPORTS.md
+++ b/docs/TRANSPORTS.md
@@ -58,8 +58,9 @@ Options:
 - `--allow-host`: comma-separated extra `Host` allowlist for DNS names or
   alternate authorities; pass a quoted `*` or an empty value to disable the check
 - `--sse-keep-alive-secs`: keep-alive interval (0 disables)
-- `--session-keep-alive-secs`: HTTP session inactivity timeout (defaults to
-  1800s with `--max-workers 1`, 300s with pooled workers; 0 disables)
+- `--session-keep-alive-secs`: HTTP session inactivity timeout (default 1800s;
+  0 disables). In pooled mode this is the fallback reclaim for POST-only
+  clients — SSE clients are reclaimed faster via `--worker-disconnect-grace-secs`.
 - `--max-workers`: maximum child worker processes for concurrent multi-IDB
   sessions; `1` keeps the legacy in-process worker
 - `--min-workers`: idle child workers to keep warm when pooled mode is enabled

--- a/docs/TRANSPORTS.md
+++ b/docs/TRANSPORTS.md
@@ -20,9 +20,12 @@ token". Phase progress is recorded server-side instead and surfaced via the
 `recent_operations` tool. Long-running work (e.g. `analyze_funcs`) should be
 launched through the task system (`enqueue_task` + poll `task_status`).
 
-## Streamable HTTP (multi-client)
+## Streamable HTTP (multi-client transport)
 
 - Supports multiple clients over HTTP.
+- By default, those clients share one IDA worker and one active IDB context.
+- For concurrent multi-IDB analysis, set `--max-workers` above `1` to enable
+  the child-process worker pool.
 - SSE is used for streaming responses within this transport.
 - The server validates `Origin` and `Host` headers. IP-literal `Host` values
   that are reachable through the bind address are accepted automatically; DNS
@@ -30,6 +33,13 @@ launched through the task system (`enqueue_task` + poll `task_status`).
 
 ```bash
 ./target/release/ida-mcp serve-http --bind 127.0.0.1:8765
+
+# Concurrent multi-IDB sessions
+./target/release/ida-mcp serve-http \
+  --bind 127.0.0.1:8765 \
+  --max-workers 4 \
+  --min-workers 1
+
 # Exposing on a LAN by IP address
 ./target/release/ida-mcp serve-http \
   --bind 0.0.0.0:8765 \
@@ -48,12 +58,28 @@ Options:
 - `--allow-host`: comma-separated extra `Host` allowlist for DNS names or
   alternate authorities; pass a quoted `*` or an empty value to disable the check
 - `--sse-keep-alive-secs`: keep-alive interval (0 disables)
-- `--session-keep-alive-secs`: HTTP session inactivity timeout (default: 1800; 0 disables)
+- `--session-keep-alive-secs`: HTTP session inactivity timeout (defaults to
+  1800s with `--max-workers 1`, 300s with pooled workers; 0 disables)
+- `--max-workers`: maximum child worker processes for concurrent multi-IDB
+  sessions; `1` keeps the legacy in-process worker
+- `--min-workers`: idle child workers to keep warm when pooled mode is enabled
+- `--worker-disconnect-grace-secs`: reconnect grace before a pooled session is
+  closed after the client drops its standalone SSE stream
 
 ## Concurrency model
 
-IDA requires main-thread access. All IDA operations are serialized through a single
-worker loop, while multiple clients can submit requests concurrently.
+IDA requires main-thread access, and one IDA process can own only one active
+database at a time. With `--max-workers 1`, all HTTP sessions are serialized
+through one worker loop. With `--max-workers N` where `N > 1`, each opened HTTP
+session leases a child `ida-mcp worker` process, so different sessions can own
+different IDBs concurrently until `close_idb`, HTTP `DELETE`, session timeout,
+or server shutdown. `close_idb` releases the lease immediately; the child
+process can remain idle for reuse until `--worker-idle-timeout-secs` elapses.
+If an SSE-capable client exits without sending `close_idb` or HTTP `DELETE`,
+pooled mode closes the abandoned session when its standalone SSE stream
+disconnects and the reconnect grace elapses. POST-only clients have no
+persistent stream to observe, so their orphaned sessions are reclaimed by
+`--session-keep-alive-secs`.
 
 ## Shutdown
 

--- a/justfile
+++ b/justfile
@@ -140,6 +140,30 @@ test-http: build
 test-http-recovery: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-http-recovery
 
+# Run HTTP worker-pool concurrency test (debug)
+test-pool: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool
+
+# Run HTTP worker-pool crash-containment test (debug)
+test-pool-crash: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool-crash
+
+# Run HTTP worker-pool exhaustion test (debug)
+test-pool-exhaustion: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool-exhaustion
+
+# Run HTTP worker-pool failed-second-open lease preservation test (debug)
+test-pool-second-open: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool-second-open
+
+# Run HTTP worker-pool abandoned-client cleanup test (debug)
+test-pool-disconnect: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool-disconnect
+
+# Run HTTP worker-pool session-manager disconnect wiring test (debug, no IDA open)
+test-pool-manager-disconnect: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool-manager-disconnect
+
 # Run IDAPython script integration test (debug)
 test-script: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-script

--- a/justfile
+++ b/justfile
@@ -184,6 +184,10 @@ test-elicitation: build
 test-dsc dsc_path="": build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-dsc {{ if dsc_path != "" { dsc_path } else { "" } }}
 
+# Verify the license-expiry preflight runs and reports a healthy license
+test-license: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=info just test-license
+
 # Run crash-guard integration test (triggers SIGSEGV, verifies server survives)
 test-crash-guard: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-crash-guard

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,17 @@ pub enum ToolError {
     #[error("Server is busy (request queue full). Please retry.")]
     Busy,
 
+    #[error(
+        "Worker pool exhausted: {active}/{max} workers are leased. Close an IDB or retry later."
+    )]
+    PoolExhausted { active: usize, max: usize },
+
+    #[error("Worker {worker_id} crashed or disconnected during {last_op}")]
+    WorkerCrashed { worker_id: usize, last_op: String },
+
+    #[error("Remote worker protocol error: {0}")]
+    RemoteProtocol(String),
+
     #[error("IDA error: {0}")]
     IdaError(String),
 

--- a/src/ida/handlers/controlflow.rs
+++ b/src/ida/handlers/controlflow.rs
@@ -376,7 +376,7 @@ pub fn handle_callgraph(
 
 #[cfg(test)]
 mod tests {
-    use super::is_direct_branch_operand;
+    use crate::ida::handlers::controlflow::is_direct_branch_operand;
     use idalib::insn::OperandType;
 
     #[test]

--- a/src/ida/handlers/database.rs
+++ b/src/ida/handlers/database.rs
@@ -244,9 +244,11 @@ pub fn handle_open(
         db
     } else {
         // Raw binary - open with auto-analysis and save to .i64
-        let out_path = raw_out_path
-            .as_ref()
-            .expect("raw binary should have out path");
+        let Some(out_path) = raw_out_path.as_ref() else {
+            return Err(ToolError::OpenFailed(
+                "raw binary output path was not initialized".to_string(),
+            ));
+        };
         info!(
             "Opening raw binary with auto-analysis (idb_out={})",
             out_path.display()

--- a/src/ida/loop_impl.rs
+++ b/src/ida/loop_impl.rs
@@ -61,6 +61,46 @@ fn check_ida_version() -> Option<String> {
     }
 }
 
+fn check_license_expiry() -> Result<(), String> {
+    if let Ok(false) = idalib::is_valid_license() {
+        return Err(
+            "IDA license is invalid (is_valid_license() returned false). \
+             Check ida.hexlic / license server reachability."
+                .to_string(),
+        );
+    }
+    let end = match idalib::license_end_date() {
+        Ok(Some(ts)) => ts,
+        Ok(None) => {
+            info!("IDA license valid (no expiry date set)");
+            return Ok(());
+        }
+        Err(e) => {
+            warn!("Could not query IDA license expiry: {e}");
+            return Ok(());
+        }
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    if end <= now {
+        let days_ago = (now - end) / 86_400;
+        return Err(format!(
+            "IDA license expired {days_ago} days ago (end_date={end}). \
+             Renew the license before opening databases; otherwise IDA's \
+             init_database() will terminate this process mid-open."
+        ));
+    }
+    let days_left = (end - now) / 86_400;
+    if days_left <= 7 {
+        warn!("IDA license expires in {days_left} days (end_date={end})");
+    } else {
+        info!("IDA license valid for {days_left} more days");
+    }
+    Ok(())
+}
+
 /// Initialize IDA on the main thread and record the version state.
 pub fn init_ida_library() -> Result<IdaInitState, String> {
     info!("Initializing IDA library (main thread)");
@@ -70,6 +110,8 @@ pub fn init_ida_library() -> Result<IdaInitState, String> {
     let version_mismatch = check_ida_version();
     if let Some(ref msg) = version_mismatch {
         error!("{msg}");
+    } else {
+        check_license_expiry()?;
     }
 
     Ok(IdaInitState {

--- a/src/ida/mod.rs
+++ b/src/ida/mod.rs
@@ -8,6 +8,8 @@ pub mod handlers;
 pub mod lock;
 mod loop_impl;
 pub mod observability;
+pub mod pool;
+mod remote;
 pub mod request;
 pub mod types;
 pub mod worker;

--- a/src/ida/pool.rs
+++ b/src/ida/pool.rs
@@ -1,0 +1,1951 @@
+//! Multi-process worker pool for HTTP sessions.
+
+use crate::error::ToolError;
+use crate::ida::observability::ProgressSender;
+use crate::ida::remote;
+use crate::ida::types::*;
+use futures_util::future::join_all;
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{CallToolResult, ClientInfo, JsonObject, LoggingMessageNotificationParam};
+use rmcp::service::{NotificationContext, Peer, RoleClient, RunningService};
+use rmcp::transport::child_process::TokioChildProcess;
+use rmcp::ServiceExt;
+use serde::de::DeserializeOwned;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::runtime::Handle;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+const CHILD_CLOSE_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Clone)]
+pub struct WorkerPoolConfig {
+    pub max_workers: usize,
+    pub min_workers: usize,
+    pub worker_idle_timeout: Duration,
+    pub worker_op_timeout: Duration,
+    pub exe_path: PathBuf,
+    pub filter_args: Vec<OsString>,
+}
+
+#[derive(Clone)]
+pub struct WorkerPool {
+    inner: Arc<Mutex<PoolInner>>,
+    config: Arc<WorkerPoolConfig>,
+}
+
+struct PoolInner {
+    children: Vec<Arc<ChildSlot>>,
+    spawning: HashSet<usize>,
+    next_id: usize,
+}
+
+pub struct ChildSlot {
+    id: usize,
+    child: Mutex<PooledChild>,
+    call_lock: Mutex<()>,
+}
+
+struct PooledChild {
+    service: Option<RunningService<RoleClient, ParentClientHandler>>,
+    peer: Peer<RoleClient>,
+    pid: Option<u32>,
+    stderr_task: JoinHandle<()>,
+    state: ChildState,
+    spawned_at: Instant,
+    last_used: Instant,
+    idb_path: Option<PathBuf>,
+}
+
+struct DeadWorker {
+    service: Option<RunningService<RoleClient, ParentClientHandler>>,
+    pid: Option<u32>,
+    age_secs: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ChildState {
+    Idle,
+    Leased { session_id: String },
+    Closing,
+    Dead,
+}
+
+#[derive(Clone)]
+pub struct PooledWorkerHandle {
+    pool: WorkerPool,
+    slot: Arc<ChildSlot>,
+    session_id: String,
+    worker_id: usize,
+}
+
+#[derive(Clone)]
+struct ParentClientHandler {
+    worker_id: usize,
+}
+
+impl ClientHandler for ParentClientHandler {
+    async fn on_logging_message(
+        &self,
+        params: LoggingMessageNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) {
+        debug!(
+            target: "ida_mcp::worker",
+            worker_id = self.worker_id,
+            level = ?params.level,
+            logger = ?params.logger,
+            data = ?params.data,
+            "child worker log"
+        );
+    }
+
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::default()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WorkerRetireReason {
+    Release,
+    Call { tool: &'static str },
+}
+
+impl WorkerRetireReason {
+    fn warn_missing_runtime(self, worker_id: usize, session_id: &str) {
+        match self {
+            Self::Release => {
+                // This should only happen after the runtime is gone; there is
+                // no safe async executor left to retire the worker.
+                warn!(
+                    worker_id,
+                    session_id = %session_id,
+                    "release cleanup was dropped outside a Tokio runtime; worker may remain unreleased"
+                );
+            }
+            Self::Call { tool } => {
+                warn!(
+                    worker_id,
+                    session_id = %session_id,
+                    tool,
+                    "pooled worker call was dropped outside a Tokio runtime; worker may remain leased"
+                );
+            }
+        }
+    }
+
+    fn warn_retiring_worker(self, worker_id: usize, session_id: &str) {
+        match self {
+            Self::Release => {
+                warn!(
+                    worker_id,
+                    session_id = %session_id,
+                    "release cleanup was dropped before worker release completed; retiring worker"
+                );
+            }
+            Self::Call { tool } => {
+                warn!(
+                    worker_id,
+                    session_id = %session_id,
+                    tool,
+                    "pooled worker call was dropped before completion; retiring worker"
+                );
+            }
+        }
+    }
+}
+
+struct WorkerRetireGuard {
+    pool: WorkerPool,
+    slot: Arc<ChildSlot>,
+    worker_id: usize,
+    session_id: String,
+    reason: WorkerRetireReason,
+    runtime: Option<Handle>,
+    armed: bool,
+}
+
+struct SpawnReservation {
+    pool: WorkerPool,
+    worker_id: usize,
+    runtime: Option<Handle>,
+    cleanup_slot: Option<Arc<ChildSlot>>,
+    armed: bool,
+}
+
+impl WorkerRetireGuard {
+    fn release(pool: WorkerPool, slot: Arc<ChildSlot>, handle: &PooledWorkerHandle) -> Self {
+        Self {
+            pool,
+            slot,
+            worker_id: handle.worker_id,
+            session_id: handle.session_id.clone(),
+            reason: WorkerRetireReason::Release,
+            runtime: Handle::try_current().ok(),
+            armed: true,
+        }
+    }
+
+    fn call(handle: &PooledWorkerHandle, tool: &'static str) -> Self {
+        Self {
+            pool: handle.pool.clone(),
+            slot: handle.slot.clone(),
+            worker_id: handle.worker_id,
+            session_id: handle.session_id.clone(),
+            reason: WorkerRetireReason::Call { tool },
+            runtime: Handle::try_current().ok(),
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for WorkerRetireGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let pool = self.pool.clone();
+        let slot = self.slot.clone();
+        let worker_id = self.worker_id;
+        let session_id = self.session_id.clone();
+        let reason = self.reason;
+        let runtime = self.runtime.clone().or_else(|| Handle::try_current().ok());
+        let Some(runtime) = runtime else {
+            reason.warn_missing_runtime(worker_id, &session_id);
+            return;
+        };
+
+        runtime.spawn(async move {
+            reason.warn_retiring_worker(worker_id, &session_id);
+            pool.mark_dead(&slot).await;
+        });
+    }
+}
+
+impl SpawnReservation {
+    fn new(pool: WorkerPool, worker_id: usize) -> Self {
+        Self {
+            pool,
+            worker_id,
+            runtime: Handle::try_current().ok(),
+            cleanup_slot: None,
+            armed: true,
+        }
+    }
+
+    fn worker_id(&self) -> usize {
+        self.worker_id
+    }
+
+    async fn finish(mut self, slot: Option<Arc<ChildSlot>>) {
+        self.cleanup_slot = slot.clone();
+        self.pool
+            .finish_spawn_reservation(self.worker_id, slot)
+            .await;
+        self.cleanup_slot = None;
+        self.armed = false;
+    }
+}
+
+impl Drop for SpawnReservation {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let pool = self.pool.clone();
+        let worker_id = self.worker_id;
+        let cleanup_slot = self.cleanup_slot.take();
+        let runtime = self.runtime.clone().or_else(|| Handle::try_current().ok());
+        let Some(runtime) = runtime else {
+            warn!(
+                worker_id,
+                "spawn reservation was dropped outside a Tokio runtime; capacity may remain reserved"
+            );
+            return;
+        };
+
+        runtime.spawn(async move {
+            warn!(
+                worker_id,
+                "spawn reservation was dropped before worker installation completed"
+            );
+            pool.finish_spawn_reservation(worker_id, None).await;
+            if let Some(slot) = cleanup_slot {
+                pool.mark_dead(&slot).await;
+            }
+        });
+    }
+}
+
+impl WorkerPool {
+    pub fn new(config: WorkerPoolConfig) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PoolInner {
+                children: Vec::new(),
+                spawning: HashSet::new(),
+                next_id: 0,
+            })),
+            config: Arc::new(config),
+        }
+    }
+
+    pub async fn warm_min(&self) -> Result<(), ToolError> {
+        let min = self.config.min_workers.min(self.config.max_workers);
+        for _ in 0..min {
+            let reservation = self.reserve_spawn_slot().await;
+            self.spawn_reserved_slot(reservation, ChildState::Idle)
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn lease(&self, session_id: &str) -> Result<PooledWorkerHandle, ToolError> {
+        let session_id = session_id.to_string();
+        let reservation = {
+            let mut inner = self.inner.lock().await;
+            let mut active = inner.spawning.len();
+            let mut dead_ids = Vec::new();
+
+            for slot in &inner.children {
+                let mut child = slot.child.lock().await;
+                if child.state == ChildState::Dead {
+                    dead_ids.push(slot.id);
+                    continue;
+                }
+                active += 1;
+                if child.state == ChildState::Idle {
+                    child.state = ChildState::Leased {
+                        session_id: session_id.clone(),
+                    };
+                    child.last_used = Instant::now();
+                    info!(
+                        worker_id = slot.id,
+                        session_id = %session_id,
+                        "leased idle IDA child worker"
+                    );
+                    return Ok(PooledWorkerHandle {
+                        pool: self.clone(),
+                        slot: slot.clone(),
+                        session_id,
+                        worker_id: slot.id,
+                    });
+                }
+            }
+
+            if !dead_ids.is_empty() {
+                inner.children.retain(|slot| !dead_ids.contains(&slot.id));
+            }
+
+            if active >= self.config.max_workers {
+                return Err(ToolError::PoolExhausted {
+                    active,
+                    max: self.config.max_workers,
+                });
+            }
+
+            self.reserve_spawn_slot_locked(&mut inner)
+        };
+
+        let id = reservation.worker_id();
+        let slot = self
+            .spawn_reserved_slot(
+                reservation,
+                ChildState::Leased {
+                    session_id: session_id.clone(),
+                },
+            )
+            .await?;
+        info!(
+            worker_id = id,
+            session_id = %session_id,
+            "spawned leased IDA child worker"
+        );
+        Ok(PooledWorkerHandle {
+            pool: self.clone(),
+            slot,
+            session_id,
+            worker_id: id,
+        })
+    }
+
+    async fn spawn_reserved_slot(
+        &self,
+        reservation: SpawnReservation,
+        initial_state: ChildState,
+    ) -> Result<Arc<ChildSlot>, ToolError> {
+        let id = reservation.worker_id();
+        match self.spawn_slot(id, initial_state).await {
+            Ok(slot) => {
+                reservation.finish(Some(slot.clone())).await;
+                Ok(slot)
+            }
+            Err(err) => {
+                reservation.finish(None).await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn reserve_spawn_slot(&self) -> SpawnReservation {
+        let mut inner = self.inner.lock().await;
+        self.reserve_spawn_slot_locked(&mut inner)
+    }
+
+    fn reserve_spawn_slot_locked(&self, inner: &mut PoolInner) -> SpawnReservation {
+        let id = inner.next_id;
+        inner.next_id += 1;
+        inner.spawning.insert(id);
+        SpawnReservation::new(self.clone(), id)
+    }
+
+    async fn finish_spawn_reservation(&self, worker_id: usize, slot: Option<Arc<ChildSlot>>) {
+        let mut inner = self.inner.lock().await;
+        inner.spawning.remove(&worker_id);
+        if let Some(slot) = slot {
+            inner.children.push(slot);
+        }
+    }
+
+    async fn spawn_slot(
+        &self,
+        id: usize,
+        initial_state: ChildState,
+    ) -> Result<Arc<ChildSlot>, ToolError> {
+        let mut cmd = tokio::process::Command::new(&self.config.exe_path);
+        cmd.args(&self.config.filter_args);
+        cmd.arg("worker");
+        cmd.kill_on_drop(true);
+
+        let (transport, stderr) = TokioChildProcess::builder(cmd)
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|err| {
+                ToolError::RemoteProtocol(format!("failed to spawn worker {id}: {err}"))
+            })?;
+        let pid = transport.id();
+        let stderr_task = spawn_stderr_relay(id, stderr);
+        let handler = ParentClientHandler { worker_id: id };
+        let service = handler.serve(transport).await.map_err(|err| {
+            ToolError::RemoteProtocol(format!("failed to initialize worker {id}: {err}"))
+        })?;
+        let peer = service.peer().clone();
+        Ok(Arc::new(ChildSlot {
+            id,
+            child: Mutex::new(PooledChild {
+                service: Some(service),
+                peer,
+                pid,
+                stderr_task,
+                state: initial_state,
+                spawned_at: Instant::now(),
+                last_used: Instant::now(),
+                idb_path: None,
+            }),
+            call_lock: Mutex::new(()),
+        }))
+    }
+
+    pub async fn release(&self, handle: PooledWorkerHandle) -> Result<(), ToolError> {
+        let result = self.release_inner(&handle).await;
+        self.schedule_idle_reap(handle.slot.clone());
+        result
+    }
+
+    async fn release_inner(&self, handle: &PooledWorkerHandle) -> Result<(), ToolError> {
+        let mut release_guard =
+            WorkerRetireGuard::release(self.clone(), handle.slot.clone(), handle);
+        let _call_guard = handle.slot.call_lock.lock().await;
+        let peer = {
+            let mut child = handle.slot.child.lock().await;
+            if child.state == ChildState::Dead {
+                release_guard.disarm();
+                return Ok(());
+            }
+            child.state = ChildState::Closing;
+            child.peer.clone()
+        };
+
+        let args = remote::json_object(json!({}))?;
+        let close = tokio::time::timeout(
+            Duration::from_secs(CHILD_CLOSE_TIMEOUT_SECS),
+            remote::call_tool(&peer, "close_idb", args),
+        )
+        .await;
+
+        let close_error = match close {
+            Ok(Ok(result)) if result.is_error != Some(true) => None,
+            Ok(Ok(result)) => remote::result_text(&result, "close_idb").err(),
+            Ok(Err(err)) => Some(err),
+            Err(_) => Some(ToolError::Timeout(CHILD_CLOSE_TIMEOUT_SECS)),
+        };
+
+        let close_error = match close_error {
+            Some(err) if release_error_retires_worker(&err) => {
+                warn!(
+                    worker_id = handle.worker_id,
+                    session_id = %handle.session_id,
+                    error = %err,
+                    "retiring IDA child worker after close_idb transport failure"
+                );
+                self.mark_dead(&handle.slot).await;
+                release_guard.disarm();
+                return Err(err);
+            }
+            other => other,
+        };
+
+        let mut child = handle.slot.child.lock().await;
+        if child.state == ChildState::Dead {
+            release_guard.disarm();
+            if let Some(err) = close_error {
+                return Err(err);
+            }
+            return Ok(());
+        }
+        child.state = ChildState::Idle;
+        child.last_used = Instant::now();
+        child.idb_path = None;
+        release_guard.disarm();
+        info!(
+            worker_id = handle.worker_id,
+            session_id = %handle.session_id,
+            "released IDA child worker"
+        );
+
+        if let Some(err) = close_error {
+            warn!(
+                worker_id = handle.worker_id,
+                session_id = %handle.session_id,
+                error = %err,
+                "child close_idb reported an error during release"
+            );
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn schedule_idle_reap(&self, slot: Arc<ChildSlot>) {
+        let pool = self.clone();
+        tokio::spawn(async move {
+            let timeout = pool.config.worker_idle_timeout;
+            if timeout.is_zero() {
+                return;
+            }
+            let sleep_started = Instant::now();
+            tokio::time::sleep(timeout).await;
+
+            pool.mark_stale_idle_dead(&slot, sleep_started).await;
+        });
+    }
+
+    pub async fn mark_dead(&self, slot: &Arc<ChildSlot>) {
+        let dead = self.take_dead_worker(slot).await;
+        self.forget_slot(slot.id).await;
+        if let Some(dead) = dead {
+            Self::finish_dead_worker(slot.id, dead).await;
+        }
+    }
+
+    async fn mark_stale_idle_dead(&self, slot: &Arc<ChildSlot>, sleep_started: Instant) {
+        let Some(dead) = self
+            .take_stale_idle_worker_if_above_min(slot, sleep_started)
+            .await
+        else {
+            return;
+        };
+        info!(worker_id = slot.id, "reaping idle IDA child worker");
+        self.forget_slot(slot.id).await;
+        Self::finish_dead_worker(slot.id, dead).await;
+    }
+
+    async fn forget_slot(&self, worker_id: usize) {
+        let mut inner = self.inner.lock().await;
+        inner.children.retain(|slot| slot.id != worker_id);
+    }
+
+    async fn take_dead_worker(&self, slot: &Arc<ChildSlot>) -> Option<DeadWorker> {
+        let mut child = slot.child.lock().await;
+        if child.state == ChildState::Dead {
+            return None;
+        }
+        Some(Self::take_dead_worker_locked(&mut child))
+    }
+
+    async fn take_stale_idle_worker_if_above_min(
+        &self,
+        slot: &Arc<ChildSlot>,
+        sleep_started: Instant,
+    ) -> Option<DeadWorker> {
+        let inner = self.inner.lock().await;
+        let mut live_count = inner.spawning.len();
+        for child_slot in &inner.children {
+            let child = child_slot.child.lock().await;
+            if child.state != ChildState::Dead {
+                live_count += 1;
+            }
+        }
+        if live_count <= self.config.min_workers {
+            return None;
+        }
+
+        let mut child = slot.child.lock().await;
+        if child.state != ChildState::Idle || child.last_used > sleep_started {
+            return None;
+        }
+        Some(Self::take_dead_worker_locked(&mut child))
+    }
+
+    fn take_dead_worker_locked(child: &mut PooledChild) -> DeadWorker {
+        child.state = ChildState::Dead;
+        child.idb_path = None;
+        let pid = child.pid;
+        let age_secs = child.spawned_at.elapsed().as_secs();
+        let service = child.service.take();
+        child.stderr_task.abort();
+        DeadWorker {
+            service,
+            pid,
+            age_secs,
+        }
+    }
+
+    async fn finish_dead_worker(worker_id: usize, mut dead: DeadWorker) {
+        if let Some(mut service) = dead.service.take() {
+            let _ = service
+                .close_with_timeout(Duration::from_secs(CHILD_CLOSE_TIMEOUT_SECS))
+                .await;
+        }
+        warn!(
+            worker_id,
+            ?dead.pid,
+            age_secs = dead.age_secs,
+            "marked IDA child worker dead"
+        );
+    }
+
+    pub async fn shutdown_all(&self) {
+        let slots = {
+            let inner = self.inner.lock().await;
+            inner.children.clone()
+        };
+        join_all(slots.into_iter().map(|slot| {
+            let pool = self.clone();
+            async move {
+                pool.mark_dead(&slot).await;
+            }
+        }))
+        .await;
+    }
+
+    #[cfg(test)]
+    async fn live_or_reserved_count(&self) -> usize {
+        let inner = self.inner.lock().await;
+        let mut count = inner.spawning.len();
+        for slot in &inner.children {
+            let child = slot.child.lock().await;
+            if child.state != ChildState::Dead {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    fn worker_op_timeout(&self, requested: Option<u64>) -> Duration {
+        let configured = self.config.worker_op_timeout;
+        requested
+            .map(Duration::from_secs)
+            .map(|requested| requested.min(configured))
+            .unwrap_or(configured)
+    }
+}
+
+impl PooledWorkerHandle {
+    pub fn worker_id(&self) -> usize {
+        self.worker_id
+    }
+
+    async fn call_tool(
+        &self,
+        tool: &'static str,
+        args: JsonObject,
+        timeout: Duration,
+        cancel: Option<CancellationToken>,
+    ) -> Result<CallToolResult, ToolError> {
+        let _call_guard = self.slot.call_lock.lock().await;
+        let peer = {
+            let child = self.slot.child.lock().await;
+            match &child.state {
+                ChildState::Leased { session_id } if session_id == &self.session_id => {
+                    child.peer.clone()
+                }
+                ChildState::Dead => {
+                    return Err(ToolError::WorkerCrashed {
+                        worker_id: self.worker_id,
+                        last_op: tool.to_string(),
+                    });
+                }
+                other => {
+                    return Err(ToolError::RemoteProtocol(format!(
+                        "worker {} is not leased to session {} (state: {other:?})",
+                        self.worker_id, self.session_id
+                    )));
+                }
+            }
+        };
+
+        let request = remote::call_tool(&peer, tool, args);
+        tokio::pin!(request);
+        let mut retire_guard = WorkerRetireGuard::call(self, tool);
+
+        let result = if let Some(cancel) = cancel {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    self.pool.mark_dead(&self.slot).await;
+                    retire_guard.disarm();
+                    return Err(ToolError::Cancelled(format!(
+                        "cancelled {tool}; killed worker {}",
+                        self.worker_id
+                    )));
+                }
+                result = tokio::time::timeout(timeout, &mut request) => result,
+            }
+        } else {
+            tokio::time::timeout(timeout, &mut request).await
+        };
+
+        match result {
+            Ok(Ok(result)) => {
+                retire_guard.disarm();
+                Ok(result)
+            }
+            Ok(Err(err)) => {
+                self.pool.mark_dead(&self.slot).await;
+                retire_guard.disarm();
+                Err(ToolError::WorkerCrashed {
+                    worker_id: self.worker_id,
+                    last_op: format!("{tool}: {err}"),
+                })
+            }
+            Err(_) => {
+                self.pool.mark_dead(&self.slot).await;
+                retire_guard.disarm();
+                Err(ToolError::TimeoutDetailed(format!(
+                    "{tool} exceeded worker operation timeout of {} seconds; killed worker {}",
+                    timeout.as_secs(),
+                    self.worker_id
+                )))
+            }
+        }
+    }
+}
+
+pub struct PooledSessionState {
+    pool: WorkerPool,
+    session_id: String,
+    handle: Arc<Mutex<Option<PooledWorkerHandle>>>,
+    runtime: Option<Handle>,
+}
+
+impl PooledSessionState {
+    pub fn new(pool: WorkerPool, session_id: String) -> Self {
+        Self {
+            pool,
+            session_id,
+            handle: Arc::new(Mutex::new(None)),
+            runtime: Handle::try_current().ok(),
+        }
+    }
+
+    async fn lease_for_open(&self) -> Result<(PooledWorkerHandle, bool), ToolError> {
+        let mut guard = self.handle.lock().await;
+        if let Some(handle) = guard.as_ref() {
+            return Ok((handle.clone(), false));
+        }
+        let handle = self.pool.lease(&self.session_id).await?;
+        *guard = Some(handle.clone());
+        Ok((handle, true))
+    }
+
+    async fn required_handle(&self) -> Result<PooledWorkerHandle, ToolError> {
+        let guard = self.handle.lock().await;
+        guard.as_ref().cloned().ok_or(ToolError::NoDatabaseOpen)
+    }
+
+    async fn take_handle(&self) -> Option<PooledWorkerHandle> {
+        self.handle.lock().await.take()
+    }
+
+    async fn release_current_handle(&self) {
+        if let Some(handle) = self.take_handle().await {
+            let _ = self.pool.release(handle).await;
+        }
+    }
+
+    async fn clear_handle_if_worker(&self, worker_id: usize) {
+        let mut guard = self.handle.lock().await;
+        if guard
+            .as_ref()
+            .is_some_and(|handle| handle.worker_id == worker_id)
+        {
+            *guard = None;
+        }
+    }
+
+    async fn call_result(
+        &self,
+        tool: &'static str,
+        args: Value,
+        timeout_secs: Option<u64>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<CallToolResult, ToolError> {
+        let handle = self.required_handle().await?;
+        let timeout = self.pool.worker_op_timeout(timeout_secs);
+        match handle
+            .call_tool(tool, remote::json_object(args)?, timeout, cancel)
+            .await
+        {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                self.clear_handle_if_worker(handle.worker_id).await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn call_json<T: DeserializeOwned>(
+        &self,
+        tool: &'static str,
+        args: Value,
+        timeout_secs: Option<u64>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<T, ToolError> {
+        let result = self.call_result(tool, args, timeout_secs, cancel).await?;
+        remote::parse_json(result, tool)
+    }
+
+    async fn call_value(
+        &self,
+        tool: &'static str,
+        args: Value,
+        timeout_secs: Option<u64>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<Value, ToolError> {
+        let result = self.call_result(tool, args, timeout_secs, cancel).await?;
+        remote::parse_value(result, tool)
+    }
+
+    async fn call_text(
+        &self,
+        tool: &'static str,
+        args: Value,
+        timeout_secs: Option<u64>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<String, ToolError> {
+        let result = self.call_result(tool, args, timeout_secs, cancel).await?;
+        remote::result_text(&result, tool)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn open_observed(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+        _progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<DbInfo, ToolError> {
+        let (handle, fresh_lease) = self.lease_for_open().await?;
+        let timeout = self.pool.worker_op_timeout(None);
+        let result = handle
+            .call_tool(
+                "open_idb",
+                remote::json_object(json!({
+                    "path": path,
+                    "load_debug_info": load_debug_info,
+                    "debug_info_path": debug_info_path,
+                    "debug_info_verbose": debug_info_verbose,
+                    "force": force,
+                    "file_type": file_type,
+                    "auto_analyse": auto_analyse,
+                    "extra_args": extra_args,
+                }))?,
+                timeout,
+                cancel,
+            )
+            .await;
+
+        match result.and_then(|result| remote::parse_json::<DbInfo>(result, "open_idb")) {
+            Ok(info) => {
+                let mut child = handle.slot.child.lock().await;
+                child.idb_path = Some(PathBuf::from(&info.path));
+                Ok(info)
+            }
+            Err(err) => {
+                if open_error_releases_lease(fresh_lease, &err) {
+                    self.release_current_handle().await;
+                }
+                Err(err)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn open(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+    ) -> Result<DbInfo, ToolError> {
+        self.open_observed(
+            path,
+            load_debug_info,
+            debug_info_path,
+            debug_info_verbose,
+            force,
+            file_type,
+            auto_analyse,
+            extra_args,
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn close(&self) -> Result<(), ToolError> {
+        let Some(handle) = self.take_handle().await else {
+            return Err(ToolError::NoDatabaseOpen);
+        };
+        self.pool.release(handle).await
+    }
+
+    pub async fn load_debug_info(
+        &self,
+        path: Option<String>,
+        verbose: bool,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "load_debug_info",
+            json!({ "path": path, "verbose": verbose }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn analysis_status(&self) -> Result<AnalysisStatus, ToolError> {
+        self.call_json("analysis_status", json!({}), None, None)
+            .await
+    }
+
+    pub async fn list_functions(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<FunctionListResult, ToolError> {
+        self.call_json(
+            "list_functions",
+            json!({ "offset": offset, "limit": limit, "filter": filter, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn resolve_function(&self, name: &str) -> Result<FunctionInfo, ToolError> {
+        self.call_json("resolve_function", json!({ "name": name }), None, None)
+            .await
+    }
+
+    pub async fn disasm_by_name(&self, name: &str, count: usize) -> Result<String, ToolError> {
+        self.call_text(
+            "disasm_by_name",
+            json!({ "name": name, "count": count }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn disasm(&self, addr: u64, count: usize) -> Result<String, ToolError> {
+        self.call_text(
+            "disasm",
+            json!({ "address": remote::hex_addr(addr), "count": count }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn decompile(&self, addr: u64) -> Result<String, ToolError> {
+        self.call_text(
+            "decompile",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn segments(&self) -> Result<Vec<SegmentInfo>, ToolError> {
+        self.call_json("segments", json!({}), None, None).await
+    }
+
+    pub async fn strings(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<StringListResult, ToolError> {
+        self.call_json(
+            "strings",
+            json!({ "offset": offset, "limit": limit, "filter": filter, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn local_types(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<LocalTypeListResult, ToolError> {
+        self.call_json(
+            "local_types",
+            json!({ "offset": offset, "limit": limit, "filter": filter, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn declare_type(
+        &self,
+        decl: String,
+        relaxed: bool,
+        replace: bool,
+        multi: bool,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "declare_type",
+            json!({ "decl": decl, "relaxed": relaxed, "replace": replace, "multi": multi }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn apply_types(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        stack_offset: Option<i64>,
+        stack_name: Option<String>,
+        decl: Option<String>,
+        type_name: Option<String>,
+        relaxed: bool,
+        delay: bool,
+        strict: bool,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "apply_types",
+            json!({
+                "address": remote::opt_hex_addr(addr),
+                "target_name": name,
+                "offset": offset,
+                "stack_offset": stack_offset,
+                "stack_name": stack_name,
+                "decl": decl,
+                "type_name": type_name,
+                "relaxed": relaxed,
+                "delay": delay,
+                "strict": strict,
+            }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn infer_types(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+    ) -> Result<GuessTypeResult, ToolError> {
+        self.call_json(
+            "infer_types",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn addr_info(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+    ) -> Result<AddressInfo, ToolError> {
+        self.call_json(
+            "addr_info",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn function_at(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+    ) -> Result<FunctionRangeInfo, ToolError> {
+        self.call_json(
+            "function_at",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn disasm_function_at(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        count: usize,
+    ) -> Result<String, ToolError> {
+        self.call_text(
+            "disasm_function_at",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "count": count }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn declare_stack(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        var_name: Option<String>,
+        decl: String,
+        relaxed: bool,
+    ) -> Result<StackVarResult, ToolError> {
+        self.call_json(
+            "declare_stack",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "var_name": var_name, "decl": decl, "relaxed": relaxed }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete_stack(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: Option<i64>,
+        var_name: Option<String>,
+    ) -> Result<StackVarResult, ToolError> {
+        self.call_json(
+            "delete_stack",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "var_name": var_name }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn stack_frame(&self, addr: u64) -> Result<FrameInfo, ToolError> {
+        self.call_json(
+            "stack_frame",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn structs(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<StructListResult, ToolError> {
+        self.call_json(
+            "structs",
+            json!({ "offset": offset, "limit": limit, "filter": filter, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn struct_info(
+        &self,
+        ordinal: Option<u32>,
+        name: Option<String>,
+    ) -> Result<StructInfo, ToolError> {
+        self.call_json(
+            "struct_info",
+            json!({ "ordinal": ordinal, "name": name }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn read_struct(
+        &self,
+        addr: u64,
+        ordinal: Option<u32>,
+        name: Option<String>,
+    ) -> Result<StructReadResult, ToolError> {
+        self.call_json(
+            "read_struct",
+            json!({ "address": remote::hex_addr(addr), "ordinal": ordinal, "name": name }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn xrefs_to(&self, addr: u64) -> Result<Vec<XRefInfo>, ToolError> {
+        self.call_json(
+            "xrefs_to",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn xrefs_from(&self, addr: u64) -> Result<Vec<XRefInfo>, ToolError> {
+        self.call_json(
+            "xrefs_from",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn xrefs_to_field(
+        &self,
+        ordinal: Option<u32>,
+        name: Option<String>,
+        member_index: Option<u32>,
+        member_name: Option<String>,
+        limit: usize,
+    ) -> Result<XrefsToFieldResult, ToolError> {
+        self.call_json(
+            "xrefs_to_field",
+            json!({ "ordinal": ordinal, "name": name, "member_index": member_index, "member_name": member_name, "limit": limit }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn imports(&self, offset: usize, limit: usize) -> Result<Vec<ImportInfo>, ToolError> {
+        self.call_json(
+            "imports",
+            json!({ "offset": offset, "limit": limit }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn exports(&self, offset: usize, limit: usize) -> Result<Vec<ExportInfo>, ToolError> {
+        self.call_json(
+            "exports",
+            json!({ "offset": offset, "limit": limit }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn entrypoints(&self) -> Result<Vec<String>, ToolError> {
+        self.call_json("entrypoints", json!({}), None, None).await
+    }
+
+    pub async fn get_bytes(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        size: usize,
+    ) -> Result<BytesResult, ToolError> {
+        self.call_json(
+            "get_bytes",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "size": size }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn set_comments(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        comment: String,
+        repeatable: bool,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "set_comments",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "comment": comment, "repeatable": repeatable }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn rename(
+        &self,
+        addr: Option<u64>,
+        current_name: Option<String>,
+        new_name: String,
+        flags: i32,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "rename",
+            json!({ "address": remote::opt_hex_addr(addr), "current_name": current_name, "name": new_name, "flags": flags }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn patch_bytes(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        bytes: Vec<u8>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "patch",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "bytes": bytes }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn patch_asm(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        line: String,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "patch_asm",
+            json!({ "address": remote::opt_hex_addr(addr), "target_name": name, "offset": offset, "line": line }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn basic_blocks(&self, addr: u64) -> Result<Vec<BasicBlockInfo>, ToolError> {
+        self.call_json(
+            "basic_blocks",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn callees(&self, addr: u64) -> Result<Vec<FunctionInfo>, ToolError> {
+        self.call_json(
+            "callees",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn callers(&self, addr: u64) -> Result<Vec<FunctionInfo>, ToolError> {
+        self.call_json(
+            "callers",
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn idb_meta(&self) -> Result<Value, ToolError> {
+        self.call_value("idb_meta", json!({}), None, None).await
+    }
+
+    pub async fn lookup_funcs(&self, queries: Vec<String>) -> Result<Value, ToolError> {
+        self.call_value("lookup_funcs", json!({ "queries": queries }), None, None)
+            .await
+    }
+
+    pub async fn list_globals(
+        &self,
+        query: Option<String>,
+        offset: usize,
+        limit: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "list_globals",
+            json!({ "query": query, "offset": offset, "limit": limit, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn analyze_strings(
+        &self,
+        query: Option<String>,
+        offset: usize,
+        limit: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "analyze_strings",
+            json!({ "query": query, "offset": offset, "limit": limit, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn find_string(
+        &self,
+        query: String,
+        exact: bool,
+        case_insensitive: bool,
+        offset: usize,
+        limit: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<StringListResult, ToolError> {
+        self.call_json(
+            "find_string",
+            json!({ "query": query, "exact": exact, "case_insensitive": case_insensitive, "offset": offset, "limit": limit, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn xrefs_to_string(
+        &self,
+        query: String,
+        exact: bool,
+        case_insensitive: bool,
+        offset: usize,
+        limit: usize,
+        max_xrefs: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<StringXrefsResult, ToolError> {
+        self.call_json(
+            "xrefs_to_string",
+            json!({ "query": query, "exact": exact, "case_insensitive": case_insensitive, "offset": offset, "limit": limit, "max_xrefs": max_xrefs, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn analyze_funcs(&self, timeout_secs: Option<u64>) -> Result<Value, ToolError> {
+        self.call_value(
+            "analyze_funcs",
+            json!({ "background": false, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn analyze_funcs_observed(
+        &self,
+        _progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "analyze_funcs",
+            json!({ "background": false }),
+            None,
+            cancel,
+        )
+        .await
+    }
+
+    pub async fn find_bytes(
+        &self,
+        pattern: String,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        let value = self
+            .call_value(
+                "find_bytes",
+                json!({ "patterns": pattern, "limit": max_results, "offset": 0, "timeout_secs": timeout_secs }),
+                timeout_secs,
+                None,
+            )
+            .await?;
+        extract_first_matches(value, "find_bytes")
+    }
+
+    pub async fn search_text(
+        &self,
+        text: String,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.search_one(text, "text", max_results, timeout_secs)
+            .await
+    }
+
+    pub async fn search_imm(
+        &self,
+        imm: u64,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.search_one(format!("0x{imm:x}"), "imm", max_results, timeout_secs)
+            .await
+    }
+
+    async fn search_one(
+        &self,
+        target: String,
+        kind: &str,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        let value = self
+            .call_value(
+                "search",
+                json!({ "targets": target, "kind": kind, "limit": max_results, "offset": 0, "timeout_secs": timeout_secs }),
+                timeout_secs,
+                None,
+            )
+            .await?;
+        extract_first_matches(value, "search")
+    }
+
+    pub async fn find_insns(
+        &self,
+        patterns: Vec<String>,
+        max_results: usize,
+        case_insensitive: bool,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "find_insns",
+            json!({ "patterns": patterns, "limit": max_results, "case_insensitive": case_insensitive, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn find_insn_operands(
+        &self,
+        patterns: Vec<String>,
+        max_results: usize,
+        case_insensitive: bool,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "find_insn_operands",
+            json!({ "patterns": patterns, "limit": max_results, "case_insensitive": case_insensitive, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn read_int(&self, addr: u64, size: usize) -> Result<Value, ToolError> {
+        let tool = match size {
+            1 => "get_u8",
+            2 => "get_u16",
+            4 => "get_u32",
+            8 => "get_u64",
+            _ => {
+                return Err(ToolError::InvalidParams(format!(
+                    "unsupported integer size: {size}"
+                )))
+            }
+        };
+        self.call_value(
+            tool,
+            json!({ "address": remote::hex_addr(addr) }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn get_string(&self, addr: u64, max_len: usize) -> Result<Value, ToolError> {
+        self.call_value(
+            "get_string",
+            json!({ "address": remote::hex_addr(addr), "max_len": max_len }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn get_global_value(&self, query: String) -> Result<Value, ToolError> {
+        self.call_value("get_global_value", json!({ "query": query }), None, None)
+            .await
+    }
+
+    pub async fn find_paths(
+        &self,
+        start: u64,
+        end: u64,
+        max_paths: usize,
+        max_depth: usize,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "find_paths",
+            json!({ "start": remote::hex_addr(start), "end": remote::hex_addr(end), "max_paths": max_paths, "max_depth": max_depth }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn callgraph(
+        &self,
+        addr: u64,
+        max_depth: usize,
+        max_nodes: usize,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "callgraph",
+            json!({ "roots": remote::hex_addr(addr), "max_depth": max_depth, "max_nodes": max_nodes }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn xref_matrix(&self, addrs: Vec<u64>) -> Result<Value, ToolError> {
+        let addrs = addrs.into_iter().map(remote::hex_addr).collect::<Vec<_>>();
+        self.call_value("xref_matrix", json!({ "addrs": addrs }), None, None)
+            .await
+    }
+
+    pub async fn export_funcs(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<FunctionListResult, ToolError> {
+        self.call_json(
+            "export_funcs",
+            json!({ "offset": offset, "limit": limit, "format": "json" }),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn run_script(
+        &self,
+        code: &str,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "run_script",
+            json!({ "code": code, "timeout_secs": timeout_secs }),
+            timeout_secs,
+            None,
+        )
+        .await
+    }
+
+    pub async fn run_script_observed(
+        &self,
+        code: &str,
+        _progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<Value, ToolError> {
+        self.call_value("run_script", json!({ "code": code }), None, cancel)
+            .await
+    }
+
+    pub async fn pseudocode_at(
+        &self,
+        addr: u64,
+        end_addr: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        self.call_value(
+            "pseudocode_at",
+            json!({ "address": remote::hex_addr(addr), "end_address": end_addr.map(|addr| format!("0x{addr:x}")) }),
+            None,
+            None,
+        )
+        .await
+    }
+}
+
+impl Drop for PooledSessionState {
+    fn drop(&mut self) {
+        let pool = self.pool.clone();
+        let handle_slot = self.handle.clone();
+        let runtime = Handle::try_current().ok().or_else(|| self.runtime.clone());
+        let Some(runtime) = runtime else {
+            warn!(
+                session_id = %self.session_id,
+                "pooled session dropped outside a Tokio runtime; worker lease may remain active"
+            );
+            return;
+        };
+        runtime.spawn(async move {
+            let Some(handle) = handle_slot.lock().await.take() else {
+                return;
+            };
+            let _ = pool.release(handle).await;
+        });
+    }
+}
+
+fn extract_first_matches(value: Value, tool: &'static str) -> Result<Value, ToolError> {
+    let results = value
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            ToolError::RemoteProtocol(format!("{tool} response did not include results"))
+        })?;
+
+    if results.len() > 1 {
+        debug!(
+            tool,
+            result_sets = results.len(),
+            "pooled worker response included multiple result sets; using the first"
+        );
+    }
+
+    let matches = results
+        .first()
+        .and_then(|first| first.get("matches"))
+        .cloned()
+        .ok_or_else(|| {
+            ToolError::RemoteProtocol(format!(
+                "{tool} response did not include results[0].matches"
+            ))
+        })?;
+    Ok(json!({ "matches": matches }))
+}
+
+fn release_error_retires_worker(err: &ToolError) -> bool {
+    matches!(
+        err,
+        ToolError::Timeout(_)
+            | ToolError::TimeoutDetailed(_)
+            | ToolError::Cancelled(_)
+            | ToolError::WorkerCrashed { .. }
+            | ToolError::RemoteProtocol(_)
+            | ToolError::WorkerClosed
+    )
+}
+
+fn open_error_releases_lease(fresh_lease: bool, err: &ToolError) -> bool {
+    fresh_lease
+        || matches!(
+            err,
+            ToolError::Timeout(_)
+                | ToolError::TimeoutDetailed(_)
+                | ToolError::Cancelled(_)
+                | ToolError::WorkerCrashed { .. }
+                | ToolError::WorkerClosed
+        )
+}
+
+fn spawn_stderr_relay(
+    worker_id: usize,
+    stderr: Option<tokio::process::ChildStderr>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(stderr) = stderr else {
+            return;
+        };
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    debug!(target: "ida_mcp::worker_stderr", worker_id, %line);
+                }
+                Ok(None) => break,
+                Err(err) => {
+                    warn!(worker_id, error = %err, "failed to read child stderr");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::ToolError;
+    use crate::ida::pool::{
+        open_error_releases_lease, release_error_retires_worker, WorkerPool, WorkerPoolConfig,
+    };
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn test_pool(max_workers: usize) -> WorkerPool {
+        WorkerPool::new(WorkerPoolConfig {
+            max_workers,
+            min_workers: 0,
+            worker_idle_timeout: Duration::from_secs(300),
+            worker_op_timeout: Duration::from_secs(600),
+            exe_path: PathBuf::from("/does/not/spawn/in/this/test"),
+            filter_args: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn release_retire_decision_keeps_ida_tool_errors_reusable() {
+        assert!(!release_error_retires_worker(&ToolError::IdaError(
+            "No database is currently open".to_string()
+        )));
+    }
+
+    #[test]
+    fn release_retire_decision_retires_transport_failures() {
+        assert!(release_error_retires_worker(&ToolError::RemoteProtocol(
+            "transport closed".to_string()
+        )));
+        assert!(release_error_retires_worker(&ToolError::Timeout(5)));
+        assert!(release_error_retires_worker(&ToolError::WorkerClosed));
+    }
+
+    #[test]
+    fn open_failure_releases_fresh_lease() {
+        assert!(open_error_releases_lease(
+            true,
+            &ToolError::IdaError("A database is already open".to_string())
+        ));
+    }
+
+    #[test]
+    fn open_failure_keeps_existing_lease_for_ida_errors() {
+        assert!(!open_error_releases_lease(
+            false,
+            &ToolError::IdaError("A database is already open".to_string())
+        ));
+    }
+
+    #[test]
+    fn open_failure_releases_existing_lease_for_worker_crash() {
+        assert!(open_error_releases_lease(
+            false,
+            &ToolError::WorkerCrashed {
+                worker_id: 7,
+                last_op: "open_idb".to_string(),
+            }
+        ));
+    }
+
+    #[test]
+    fn open_failure_releases_existing_lease_for_cancellation() {
+        assert!(open_error_releases_lease(
+            false,
+            &ToolError::Cancelled("cancelled open_idb".to_string())
+        ));
+    }
+
+    #[test]
+    fn open_failure_releases_existing_lease_for_closed_worker() {
+        assert!(open_error_releases_lease(false, &ToolError::WorkerClosed));
+    }
+
+    #[tokio::test]
+    async fn spawn_reservation_counts_toward_pool_capacity() {
+        let pool = test_pool(1);
+        let reservation = pool.reserve_spawn_slot().await;
+
+        assert_eq!(pool.live_or_reserved_count().await, 1);
+        let err = match pool.lease("session-b").await {
+            Ok(_) => panic!("lease should fail while the only slot is reserved"),
+            Err(err) => err,
+        };
+        match err {
+            ToolError::PoolExhausted { active, max } => {
+                assert_eq!(active, 1);
+                assert_eq!(max, 1);
+            }
+            other => panic!("unexpected lease error: {other}"),
+        }
+
+        reservation.finish(None).await;
+        assert_eq!(pool.live_or_reserved_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn dropped_spawn_reservation_releases_pool_capacity() {
+        let pool = test_pool(1);
+        let reservation = pool.reserve_spawn_slot().await;
+        drop(reservation);
+
+        for _ in 0..10 {
+            if pool.live_or_reserved_count().await == 0 {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        panic!("dropped spawn reservation did not release capacity");
+    }
+}

--- a/src/ida/remote.rs
+++ b/src/ida/remote.rs
@@ -1,0 +1,161 @@
+//! Helpers for calling a child `ida-mcp worker` over MCP stdio.
+
+use crate::error::ToolError;
+use rmcp::model::{CallToolRequestParams, CallToolResult, JsonObject};
+use rmcp::service::{Peer, RoleClient};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+pub(crate) fn hex_addr(addr: u64) -> Value {
+    Value::String(format!("0x{addr:x}"))
+}
+
+pub(crate) fn opt_hex_addr(addr: Option<u64>) -> Value {
+    addr.map(hex_addr).unwrap_or(Value::Null)
+}
+
+pub(crate) fn json_object(value: Value) -> Result<JsonObject, ToolError> {
+    match value {
+        Value::Object(map) => Ok(map),
+        other => Err(ToolError::RemoteProtocol(format!(
+            "tool arguments must be a JSON object, got {other:?}"
+        ))),
+    }
+}
+
+pub(crate) fn strip_worker_metadata(value: &mut Value) {
+    let Value::Object(map) = value else {
+        return;
+    };
+    for key in [
+        "session_id",
+        "close_hint",
+        "close_owner_session_id",
+        "close_token",
+        "close_token_reused",
+        "close_recovery_hint",
+    ] {
+        map.remove(key);
+    }
+}
+
+pub(crate) fn result_text(result: &CallToolResult, tool: &str) -> Result<String, ToolError> {
+    if result.is_error == Some(true) {
+        return Err(ToolError::IdaError(result_error_message(result, tool)));
+    }
+
+    let Some(text) = result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.clone())
+    else {
+        return Err(ToolError::RemoteProtocol(format!(
+            "child tool {tool} returned no text content"
+        )));
+    };
+
+    if result.content.len() != 1 {
+        return Err(ToolError::RemoteProtocol(format!(
+            "child tool {tool} returned {} content items; expected 1",
+            result.content.len()
+        )));
+    }
+
+    Ok(text)
+}
+
+fn result_error_message(result: &CallToolResult, tool: &str) -> String {
+    result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.clone())
+        .unwrap_or_else(|| format!("child tool {tool} returned an error"))
+}
+
+fn result_error(result: &CallToolResult, tool: &str) -> Option<ToolError> {
+    if result.is_error != Some(true) {
+        return None;
+    }
+
+    Some(ToolError::IdaError(result_error_message(result, tool)))
+}
+
+pub(crate) fn parse_json<T: DeserializeOwned>(
+    result: CallToolResult,
+    tool: &str,
+) -> Result<T, ToolError> {
+    if let Some(err) = result_error(&result, tool) {
+        return Err(err);
+    }
+
+    if let Some(mut structured) = result.structured_content.clone() {
+        strip_worker_metadata(&mut structured);
+        return serde_json::from_value(structured).map_err(|err| {
+            ToolError::RemoteProtocol(format!("failed to parse {tool} structured response: {err}"))
+        });
+    }
+
+    let text = result_text(&result, tool)?;
+    let mut value = serde_json::from_str::<Value>(&text).map_err(|err| {
+        ToolError::RemoteProtocol(format!("failed to parse {tool} JSON response: {err}"))
+    })?;
+    strip_worker_metadata(&mut value);
+    serde_json::from_value(value)
+        .map_err(|err| ToolError::RemoteProtocol(format!("invalid {tool} response: {err}")))
+}
+
+pub(crate) fn parse_value(result: CallToolResult, tool: &str) -> Result<Value, ToolError> {
+    if let Some(err) = result_error(&result, tool) {
+        return Err(err);
+    }
+
+    if let Some(mut structured) = result.structured_content.clone() {
+        strip_worker_metadata(&mut structured);
+        return Ok(structured);
+    }
+    let text = result_text(&result, tool)?;
+    let mut value = serde_json::from_str::<Value>(&text).map_err(|err| {
+        ToolError::RemoteProtocol(format!("failed to parse {tool} JSON response: {err}"))
+    })?;
+    strip_worker_metadata(&mut value);
+    Ok(value)
+}
+
+pub(crate) async fn call_tool(
+    peer: &Peer<RoleClient>,
+    tool: &'static str,
+    args: JsonObject,
+) -> Result<CallToolResult, ToolError> {
+    peer.call_tool(CallToolRequestParams::new(tool).with_arguments(args))
+        .await
+        .map_err(|err| ToolError::RemoteProtocol(format!("{tool} call failed: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::ToolError;
+    use crate::ida::remote::{parse_json, parse_value};
+    use rmcp::model::{CallToolResult, Content};
+    use serde_json::{json, Value};
+
+    #[test]
+    fn parse_value_rejects_structured_error_results() {
+        let result = CallToolResult::structured_error(json!({ "message": "bad idb" }));
+
+        let err = parse_value(result, "open_idb").expect_err("structured error must fail");
+
+        assert!(matches!(err, ToolError::IdaError(message) if message.contains("bad idb")));
+    }
+
+    #[test]
+    fn parse_json_rejects_structured_error_results() {
+        let mut result = CallToolResult::structured_error(json!({ "path": "/tmp/example.i64" }));
+        result.content = vec![Content::text("child failed")];
+
+        let err = parse_json::<Value>(result, "open_idb").expect_err("structured error must fail");
+
+        assert!(matches!(err, ToolError::IdaError(message) if message == "child failed"));
+    }
+}

--- a/src/ida/types.rs
+++ b/src/ida/types.rs
@@ -1,9 +1,9 @@
 //! Response types for IDA worker operations.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Database info returned after opening
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DbInfo {
     pub path: String,
     pub file_type: String,
@@ -14,14 +14,14 @@ pub struct DbInfo {
     pub analysis_status: AnalysisStatus,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DebugInfoLoad {
     pub path: String,
     pub loaded: bool,
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AnalysisStatus {
     pub auto_enabled: bool,
     pub auto_is_ok: bool,
@@ -30,7 +30,7 @@ pub struct AnalysisStatus {
     pub analysis_running: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SymbolInfo {
     pub name: String,
     pub address: String,
@@ -40,7 +40,7 @@ pub struct SymbolInfo {
     pub is_weak: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FunctionRangeInfo {
     pub address: String,
     pub name: String,
@@ -49,7 +49,7 @@ pub struct FunctionRangeInfo {
     pub size: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AddressInfo {
     pub address: String,
     pub segment: Option<SegmentInfo>,
@@ -58,7 +58,7 @@ pub struct AddressInfo {
 }
 
 /// Function info for listing
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FunctionInfo {
     pub address: String,
     pub name: String,
@@ -66,7 +66,7 @@ pub struct FunctionInfo {
 }
 
 /// Paginated function list result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FunctionListResult {
     pub functions: Vec<FunctionInfo>,
     pub total: usize,
@@ -75,7 +75,7 @@ pub struct FunctionListResult {
 }
 
 /// Segment info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SegmentInfo {
     pub name: String,
     pub start: String,
@@ -87,7 +87,7 @@ pub struct SegmentInfo {
 }
 
 /// String info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StringInfo {
     pub address: String,
     pub content: String,
@@ -95,7 +95,7 @@ pub struct StringInfo {
 }
 
 /// String list result with pagination
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StringListResult {
     pub strings: Vec<StringInfo>,
     pub total: usize,
@@ -103,7 +103,7 @@ pub struct StringListResult {
     pub next_offset: Option<usize>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StringXrefInfo {
     pub address: String,
     pub content: String,
@@ -112,7 +112,7 @@ pub struct StringXrefInfo {
     pub xref_count: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StringXrefsResult {
     pub strings: Vec<StringXrefInfo>,
     pub total: usize,
@@ -121,7 +121,7 @@ pub struct StringXrefsResult {
 }
 
 /// Local type info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocalTypeInfo {
     pub ordinal: u32,
     pub name: String,
@@ -130,7 +130,7 @@ pub struct LocalTypeInfo {
 }
 
 /// Local types list result with pagination
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocalTypeListResult {
     pub types: Vec<LocalTypeInfo>,
     pub total: usize,
@@ -139,14 +139,14 @@ pub struct LocalTypeListResult {
 }
 
 /// Frame range info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FrameRange {
     pub start: String,
     pub end: String,
 }
 
 /// Stack frame member info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FrameMemberInfo {
     pub name: String,
     pub type_name: String,
@@ -159,7 +159,7 @@ pub struct FrameMemberInfo {
 }
 
 /// Stack frame info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FrameInfo {
     pub address: String,
     pub frame_size: u64,
@@ -177,7 +177,7 @@ pub struct FrameInfo {
 }
 
 /// Struct summary info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructSummary {
     pub ordinal: u32,
     pub name: String,
@@ -187,7 +187,7 @@ pub struct StructSummary {
 }
 
 /// Struct list result with pagination
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructListResult {
     pub structs: Vec<StructSummary>,
     pub total: usize,
@@ -196,7 +196,7 @@ pub struct StructListResult {
 }
 
 /// Struct member info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructMemberInfo {
     pub name: String,
     pub type_name: String,
@@ -208,7 +208,7 @@ pub struct StructMemberInfo {
 }
 
 /// Struct detailed info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructInfo {
     pub ordinal: u32,
     pub name: String,
@@ -219,7 +219,7 @@ pub struct StructInfo {
 }
 
 /// Struct member value
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructMemberValue {
     pub name: String,
     pub type_name: String,
@@ -232,7 +232,7 @@ pub struct StructMemberValue {
 }
 
 /// Struct read result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructReadResult {
     pub address: String,
     pub ordinal: u32,
@@ -242,7 +242,7 @@ pub struct StructReadResult {
 }
 
 /// Cross-reference info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct XRefInfo {
     pub from: String,
     pub to: String,
@@ -251,7 +251,7 @@ pub struct XRefInfo {
 }
 
 /// Declared type result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DeclareTypeResult {
     pub code: i32,
     pub name: String,
@@ -261,13 +261,13 @@ pub struct DeclareTypeResult {
 }
 
 /// Declare multiple types result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DeclareTypesResult {
     pub errors: i32,
 }
 
 /// Applied type result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ApplyTypeResult {
     pub address: String,
     pub applied: bool,
@@ -275,7 +275,7 @@ pub struct ApplyTypeResult {
 }
 
 /// Guess type result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GuessTypeResult {
     pub address: String,
     pub code: i32,
@@ -285,7 +285,7 @@ pub struct GuessTypeResult {
 }
 
 /// Stack variable operation result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StackVarResult {
     pub function: String,
     pub name: String,
@@ -295,7 +295,7 @@ pub struct StackVarResult {
 }
 
 /// Xrefs to a struct field
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct XrefsToFieldResult {
     pub struct_ordinal: u32,
     pub struct_name: String,
@@ -310,7 +310,7 @@ pub struct XrefsToFieldResult {
 }
 
 /// Import info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ImportInfo {
     pub address: String,
     pub name: String,
@@ -318,7 +318,7 @@ pub struct ImportInfo {
 }
 
 /// Export/Name info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExportInfo {
     pub address: String,
     pub name: String,
@@ -326,7 +326,7 @@ pub struct ExportInfo {
 }
 
 /// Global variable/name info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GlobalInfo {
     pub address: String,
     pub name: String,
@@ -336,7 +336,7 @@ pub struct GlobalInfo {
 }
 
 /// Basic block info
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BasicBlockInfo {
     pub start: String,
     pub end: String,
@@ -347,7 +347,7 @@ pub struct BasicBlockInfo {
 }
 
 /// Bytes result
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BytesResult {
     pub address: String,
     pub bytes: String,

--- a/src/ida/worker.rs
+++ b/src/ida/worker.rs
@@ -2,6 +2,7 @@
 
 use crate::error::ToolError;
 use crate::ida::observability::ProgressSender;
+use crate::ida::pool::PooledSessionState;
 use crate::ida::request::IdaRequest;
 use crate::ida::types::*;
 use serde_json::Value;
@@ -1170,9 +1171,940 @@ impl IdaWorker {
     }
 }
 
+/// Dispatch surface used by MCP handlers.
+///
+/// The local variant preserves the existing in-process worker path. The pooled
+/// variant routes calls through a per-session child process lease.
+#[derive(Clone)]
+pub enum WorkerBackend {
+    Local(Arc<IdaWorker>),
+    Pooled(Arc<PooledSessionState>),
+}
+
+impl WorkerBackend {
+    pub fn local(worker: Arc<IdaWorker>) -> Self {
+        Self::Local(worker)
+    }
+
+    pub fn pooled(state: Arc<PooledSessionState>) -> Self {
+        Self::Pooled(state)
+    }
+
+    pub(crate) fn uses_close_tokens(&self) -> bool {
+        matches!(self, Self::Local(_))
+    }
+
+    pub(crate) fn is_pooled(&self) -> bool {
+        matches!(self, Self::Pooled(_))
+    }
+
+    pub(crate) fn issue_close_token_for_session(
+        &self,
+        session_id: &str,
+    ) -> Option<Result<CloseTokenGrant, String>> {
+        match self {
+            Self::Local(worker) => Some(worker.issue_close_token_for_session(session_id)),
+            Self::Pooled(_) => None,
+        }
+    }
+
+    pub(crate) fn authorize_close(
+        &self,
+        session_id: &str,
+        token: Option<&str>,
+        force: bool,
+    ) -> CloseAuthorization {
+        match self {
+            Self::Local(worker) => worker.authorize_close(session_id, token, force),
+            // Pooled HTTP workers are private to one rmcp session, so close_idb
+            // cannot affect another client's database and does not need a
+            // cross-session recovery token.
+            Self::Pooled(_) => CloseAuthorization::Granted,
+        }
+    }
+
+    pub(crate) fn clear_close_token(&self) {
+        if let Self::Local(worker) = self {
+            worker.clear_close_token();
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn open(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+    ) -> Result<DbInfo, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .open(
+                        path,
+                        load_debug_info,
+                        debug_info_path,
+                        debug_info_verbose,
+                        force,
+                        file_type,
+                        auto_analyse,
+                        extra_args,
+                    )
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .open(
+                        path,
+                        load_debug_info,
+                        debug_info_path,
+                        debug_info_verbose,
+                        force,
+                        file_type,
+                        auto_analyse,
+                        extra_args,
+                    )
+                    .await
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn open_observed(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+        progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<DbInfo, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .open_observed(
+                        path,
+                        load_debug_info,
+                        debug_info_path,
+                        debug_info_verbose,
+                        force,
+                        file_type,
+                        auto_analyse,
+                        extra_args,
+                        progress_tx,
+                        cancel,
+                    )
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .open_observed(
+                        path,
+                        load_debug_info,
+                        debug_info_path,
+                        debug_info_verbose,
+                        force,
+                        file_type,
+                        auto_analyse,
+                        extra_args,
+                        progress_tx,
+                        cancel,
+                    )
+                    .await
+            }
+        }
+    }
+
+    pub async fn close(&self) -> Result<(), ToolError> {
+        match self {
+            Self::Local(worker) => worker.close().await,
+            Self::Pooled(state) => state.close().await,
+        }
+    }
+
+    pub async fn close_for_shutdown(&self) -> Result<(), ToolError> {
+        match self {
+            Self::Local(worker) => worker.close_for_shutdown().await,
+            Self::Pooled(state) => state.close().await,
+        }
+    }
+
+    pub async fn shutdown(&self) -> Result<(), ToolError> {
+        match self {
+            Self::Local(worker) => worker.shutdown().await,
+            Self::Pooled(_) => Ok(()),
+        }
+    }
+
+    pub async fn load_debug_info(
+        &self,
+        path: Option<String>,
+        verbose: bool,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.load_debug_info(path, verbose).await,
+            Self::Pooled(state) => state.load_debug_info(path, verbose).await,
+        }
+    }
+
+    pub async fn analysis_status(&self) -> Result<AnalysisStatus, ToolError> {
+        match self {
+            Self::Local(worker) => worker.analysis_status().await,
+            Self::Pooled(state) => state.analysis_status().await,
+        }
+    }
+
+    pub async fn list_functions(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<FunctionListResult, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .list_functions(offset, limit, filter, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .list_functions(offset, limit, filter, timeout_secs)
+                    .await
+            }
+        }
+    }
+
+    pub async fn resolve_function(&self, name: &str) -> Result<FunctionInfo, ToolError> {
+        match self {
+            Self::Local(worker) => worker.resolve_function(name).await,
+            Self::Pooled(state) => state.resolve_function(name).await,
+        }
+    }
+
+    pub async fn disasm_by_name(&self, name: &str, count: usize) -> Result<String, ToolError> {
+        match self {
+            Self::Local(worker) => worker.disasm_by_name(name, count).await,
+            Self::Pooled(state) => state.disasm_by_name(name, count).await,
+        }
+    }
+
+    pub async fn disasm(&self, addr: u64, count: usize) -> Result<String, ToolError> {
+        match self {
+            Self::Local(worker) => worker.disasm(addr, count).await,
+            Self::Pooled(state) => state.disasm(addr, count).await,
+        }
+    }
+
+    pub async fn decompile(&self, addr: u64) -> Result<String, ToolError> {
+        match self {
+            Self::Local(worker) => worker.decompile(addr).await,
+            Self::Pooled(state) => state.decompile(addr).await,
+        }
+    }
+
+    pub async fn segments(&self) -> Result<Vec<SegmentInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.segments().await,
+            Self::Pooled(state) => state.segments().await,
+        }
+    }
+
+    pub async fn strings(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<StringListResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.strings(offset, limit, filter, timeout_secs).await,
+            Self::Pooled(state) => state.strings(offset, limit, filter, timeout_secs).await,
+        }
+    }
+
+    pub async fn local_types(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<LocalTypeListResult, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .local_types(offset, limit, filter, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => state.local_types(offset, limit, filter, timeout_secs).await,
+        }
+    }
+
+    pub async fn declare_type(
+        &self,
+        decl: String,
+        relaxed: bool,
+        replace: bool,
+        multi: bool,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.declare_type(decl, relaxed, replace, multi).await,
+            Self::Pooled(state) => state.declare_type(decl, relaxed, replace, multi).await,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn apply_types(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        stack_offset: Option<i64>,
+        stack_name: Option<String>,
+        decl: Option<String>,
+        type_name: Option<String>,
+        relaxed: bool,
+        delay: bool,
+        strict: bool,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .apply_types(
+                        addr,
+                        name,
+                        offset,
+                        stack_offset,
+                        stack_name,
+                        decl,
+                        type_name,
+                        relaxed,
+                        delay,
+                        strict,
+                    )
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .apply_types(
+                        addr,
+                        name,
+                        offset,
+                        stack_offset,
+                        stack_name,
+                        decl,
+                        type_name,
+                        relaxed,
+                        delay,
+                        strict,
+                    )
+                    .await
+            }
+        }
+    }
+
+    pub async fn infer_types(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+    ) -> Result<GuessTypeResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.infer_types(addr, name, offset).await,
+            Self::Pooled(state) => state.infer_types(addr, name, offset).await,
+        }
+    }
+
+    pub async fn addr_info(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+    ) -> Result<AddressInfo, ToolError> {
+        match self {
+            Self::Local(worker) => worker.addr_info(addr, name, offset).await,
+            Self::Pooled(state) => state.addr_info(addr, name, offset).await,
+        }
+    }
+
+    pub async fn function_at(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+    ) -> Result<FunctionRangeInfo, ToolError> {
+        match self {
+            Self::Local(worker) => worker.function_at(addr, name, offset).await,
+            Self::Pooled(state) => state.function_at(addr, name, offset).await,
+        }
+    }
+
+    pub async fn disasm_function_at(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        count: usize,
+    ) -> Result<String, ToolError> {
+        match self {
+            Self::Local(worker) => worker.disasm_function_at(addr, name, offset, count).await,
+            Self::Pooled(state) => state.disasm_function_at(addr, name, offset, count).await,
+        }
+    }
+
+    pub async fn declare_stack(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        var_name: Option<String>,
+        decl: String,
+        relaxed: bool,
+    ) -> Result<StackVarResult, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .declare_stack(addr, name, offset, var_name, decl, relaxed)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .declare_stack(addr, name, offset, var_name, decl, relaxed)
+                    .await
+            }
+        }
+    }
+
+    pub async fn delete_stack(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: Option<i64>,
+        var_name: Option<String>,
+    ) -> Result<StackVarResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.delete_stack(addr, name, offset, var_name).await,
+            Self::Pooled(state) => state.delete_stack(addr, name, offset, var_name).await,
+        }
+    }
+
+    pub async fn stack_frame(&self, addr: u64) -> Result<FrameInfo, ToolError> {
+        match self {
+            Self::Local(worker) => worker.stack_frame(addr).await,
+            Self::Pooled(state) => state.stack_frame(addr).await,
+        }
+    }
+
+    pub async fn structs(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter: Option<String>,
+        timeout_secs: Option<u64>,
+    ) -> Result<StructListResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.structs(offset, limit, filter, timeout_secs).await,
+            Self::Pooled(state) => state.structs(offset, limit, filter, timeout_secs).await,
+        }
+    }
+
+    pub async fn struct_info(
+        &self,
+        ordinal: Option<u32>,
+        name: Option<String>,
+    ) -> Result<StructInfo, ToolError> {
+        match self {
+            Self::Local(worker) => worker.struct_info(ordinal, name).await,
+            Self::Pooled(state) => state.struct_info(ordinal, name).await,
+        }
+    }
+
+    pub async fn read_struct(
+        &self,
+        addr: u64,
+        ordinal: Option<u32>,
+        name: Option<String>,
+    ) -> Result<StructReadResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.read_struct(addr, ordinal, name).await,
+            Self::Pooled(state) => state.read_struct(addr, ordinal, name).await,
+        }
+    }
+
+    pub async fn xrefs_to(&self, addr: u64) -> Result<Vec<XRefInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.xrefs_to(addr).await,
+            Self::Pooled(state) => state.xrefs_to(addr).await,
+        }
+    }
+
+    pub async fn xrefs_from(&self, addr: u64) -> Result<Vec<XRefInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.xrefs_from(addr).await,
+            Self::Pooled(state) => state.xrefs_from(addr).await,
+        }
+    }
+
+    pub async fn xrefs_to_field(
+        &self,
+        ordinal: Option<u32>,
+        name: Option<String>,
+        member_index: Option<u32>,
+        member_name: Option<String>,
+        limit: usize,
+    ) -> Result<XrefsToFieldResult, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .xrefs_to_field(ordinal, name, member_index, member_name, limit)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .xrefs_to_field(ordinal, name, member_index, member_name, limit)
+                    .await
+            }
+        }
+    }
+
+    pub async fn imports(&self, offset: usize, limit: usize) -> Result<Vec<ImportInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.imports(offset, limit).await,
+            Self::Pooled(state) => state.imports(offset, limit).await,
+        }
+    }
+
+    pub async fn exports(&self, offset: usize, limit: usize) -> Result<Vec<ExportInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.exports(offset, limit).await,
+            Self::Pooled(state) => state.exports(offset, limit).await,
+        }
+    }
+
+    pub async fn entrypoints(&self) -> Result<Vec<String>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.entrypoints().await,
+            Self::Pooled(state) => state.entrypoints().await,
+        }
+    }
+
+    pub async fn get_bytes(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        size: usize,
+    ) -> Result<BytesResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.get_bytes(addr, name, offset, size).await,
+            Self::Pooled(state) => state.get_bytes(addr, name, offset, size).await,
+        }
+    }
+
+    pub async fn set_comments(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        comment: String,
+        repeatable: bool,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .set_comments(addr, name, offset, comment, repeatable)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .set_comments(addr, name, offset, comment, repeatable)
+                    .await
+            }
+        }
+    }
+
+    pub async fn rename(
+        &self,
+        addr: Option<u64>,
+        current_name: Option<String>,
+        new_name: String,
+        flags: i32,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.rename(addr, current_name, new_name, flags).await,
+            Self::Pooled(state) => state.rename(addr, current_name, new_name, flags).await,
+        }
+    }
+
+    pub async fn patch_bytes(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        bytes: Vec<u8>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.patch_bytes(addr, name, offset, bytes).await,
+            Self::Pooled(state) => state.patch_bytes(addr, name, offset, bytes).await,
+        }
+    }
+
+    pub async fn patch_asm(
+        &self,
+        addr: Option<u64>,
+        name: Option<String>,
+        offset: i64,
+        line: String,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.patch_asm(addr, name, offset, line).await,
+            Self::Pooled(state) => state.patch_asm(addr, name, offset, line).await,
+        }
+    }
+
+    pub async fn basic_blocks(&self, addr: u64) -> Result<Vec<BasicBlockInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.basic_blocks(addr).await,
+            Self::Pooled(state) => state.basic_blocks(addr).await,
+        }
+    }
+
+    pub async fn callees(&self, addr: u64) -> Result<Vec<FunctionInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.callees(addr).await,
+            Self::Pooled(state) => state.callees(addr).await,
+        }
+    }
+
+    pub async fn callers(&self, addr: u64) -> Result<Vec<FunctionInfo>, ToolError> {
+        match self {
+            Self::Local(worker) => worker.callers(addr).await,
+            Self::Pooled(state) => state.callers(addr).await,
+        }
+    }
+
+    pub async fn idb_meta(&self) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.idb_meta().await,
+            Self::Pooled(state) => state.idb_meta().await,
+        }
+    }
+
+    pub async fn lookup_funcs(&self, queries: Vec<String>) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.lookup_funcs(queries).await,
+            Self::Pooled(state) => state.lookup_funcs(queries).await,
+        }
+    }
+
+    pub async fn list_globals(
+        &self,
+        query: Option<String>,
+        offset: usize,
+        limit: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .list_globals(query, offset, limit, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => state.list_globals(query, offset, limit, timeout_secs).await,
+        }
+    }
+
+    pub async fn analyze_strings(
+        &self,
+        query: Option<String>,
+        offset: usize,
+        limit: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .analyze_strings(query, offset, limit, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .analyze_strings(query, offset, limit, timeout_secs)
+                    .await
+            }
+        }
+    }
+
+    pub async fn find_string(
+        &self,
+        query: String,
+        exact: bool,
+        case_insensitive: bool,
+        offset: usize,
+        limit: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<StringListResult, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .find_string(query, exact, case_insensitive, offset, limit, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .find_string(query, exact, case_insensitive, offset, limit, timeout_secs)
+                    .await
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn xrefs_to_string(
+        &self,
+        query: String,
+        exact: bool,
+        case_insensitive: bool,
+        offset: usize,
+        limit: usize,
+        max_xrefs: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<StringXrefsResult, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .xrefs_to_string(
+                        query,
+                        exact,
+                        case_insensitive,
+                        offset,
+                        limit,
+                        max_xrefs,
+                        timeout_secs,
+                    )
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .xrefs_to_string(
+                        query,
+                        exact,
+                        case_insensitive,
+                        offset,
+                        limit,
+                        max_xrefs,
+                        timeout_secs,
+                    )
+                    .await
+            }
+        }
+    }
+
+    pub async fn analyze_funcs(&self, timeout_secs: Option<u64>) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.analyze_funcs(timeout_secs).await,
+            Self::Pooled(state) => state.analyze_funcs(timeout_secs).await,
+        }
+    }
+
+    pub async fn analyze_funcs_observed(
+        &self,
+        progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.analyze_funcs_observed(progress_tx, cancel).await,
+            Self::Pooled(state) => state.analyze_funcs_observed(progress_tx, cancel).await,
+        }
+    }
+
+    pub async fn find_bytes(
+        &self,
+        pattern: String,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.find_bytes(pattern, max_results, timeout_secs).await,
+            Self::Pooled(state) => state.find_bytes(pattern, max_results, timeout_secs).await,
+        }
+    }
+
+    pub async fn search_text(
+        &self,
+        text: String,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.search_text(text, max_results, timeout_secs).await,
+            Self::Pooled(state) => state.search_text(text, max_results, timeout_secs).await,
+        }
+    }
+
+    pub async fn search_imm(
+        &self,
+        imm: u64,
+        max_results: usize,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.search_imm(imm, max_results, timeout_secs).await,
+            Self::Pooled(state) => state.search_imm(imm, max_results, timeout_secs).await,
+        }
+    }
+
+    pub async fn find_insns(
+        &self,
+        patterns: Vec<String>,
+        max_results: usize,
+        case_insensitive: bool,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .find_insns(patterns, max_results, case_insensitive, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .find_insns(patterns, max_results, case_insensitive, timeout_secs)
+                    .await
+            }
+        }
+    }
+
+    pub async fn find_insn_operands(
+        &self,
+        patterns: Vec<String>,
+        max_results: usize,
+        case_insensitive: bool,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => {
+                worker
+                    .find_insn_operands(patterns, max_results, case_insensitive, timeout_secs)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .find_insn_operands(patterns, max_results, case_insensitive, timeout_secs)
+                    .await
+            }
+        }
+    }
+
+    pub async fn read_int(&self, addr: u64, size: usize) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.read_int(addr, size).await,
+            Self::Pooled(state) => state.read_int(addr, size).await,
+        }
+    }
+
+    pub async fn get_string(&self, addr: u64, max_len: usize) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.get_string(addr, max_len).await,
+            Self::Pooled(state) => state.get_string(addr, max_len).await,
+        }
+    }
+
+    pub async fn get_global_value(&self, query: String) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.get_global_value(query).await,
+            Self::Pooled(state) => state.get_global_value(query).await,
+        }
+    }
+
+    pub async fn find_paths(
+        &self,
+        start: u64,
+        end: u64,
+        max_paths: usize,
+        max_depth: usize,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.find_paths(start, end, max_paths, max_depth).await,
+            Self::Pooled(state) => state.find_paths(start, end, max_paths, max_depth).await,
+        }
+    }
+
+    pub async fn callgraph(
+        &self,
+        addr: u64,
+        max_depth: usize,
+        max_nodes: usize,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.callgraph(addr, max_depth, max_nodes).await,
+            Self::Pooled(state) => state.callgraph(addr, max_depth, max_nodes).await,
+        }
+    }
+
+    pub async fn xref_matrix(&self, addrs: Vec<u64>) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.xref_matrix(addrs).await,
+            Self::Pooled(state) => state.xref_matrix(addrs).await,
+        }
+    }
+
+    pub async fn export_funcs(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<FunctionListResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.export_funcs(offset, limit).await,
+            Self::Pooled(state) => state.export_funcs(offset, limit).await,
+        }
+    }
+
+    pub async fn run_script(
+        &self,
+        code: &str,
+        timeout_secs: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.run_script(code, timeout_secs).await,
+            Self::Pooled(state) => state.run_script(code, timeout_secs).await,
+        }
+    }
+
+    pub async fn run_script_observed(
+        &self,
+        code: &str,
+        progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.run_script_observed(code, progress_tx, cancel).await,
+            Self::Pooled(state) => state.run_script_observed(code, progress_tx, cancel).await,
+        }
+    }
+
+    pub async fn pseudocode_at(
+        &self,
+        addr: u64,
+        end_addr: Option<u64>,
+    ) -> Result<Value, ToolError> {
+        match self {
+            Self::Local(worker) => worker.pseudocode_at(addr, end_addr).await,
+            Self::Pooled(state) => state.pseudocode_at(addr, end_addr).await,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CloseAuthorization, IdaWorker};
+    use crate::ida::worker::{CloseAuthorization, IdaWorker};
     use std::sync::mpsc;
 
     fn test_worker() -> IdaWorker {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,7 @@ use tracing::{error, info, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 const REQUEST_QUEUE_CAPACITY: usize = 64;
-const LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS: u64 = 1800;
-const POOLED_HTTP_SESSION_KEEP_ALIVE_SECS: u64 = 300;
+const DEFAULT_HTTP_SESSION_KEEP_ALIVE_SECS: u64 = 1800;
 
 #[derive(Parser)]
 #[command(name = "ida-mcp", version, about = "Headless IDA Pro MCP Server")]
@@ -145,10 +144,11 @@ struct ServeHttpArgs {
     #[arg(long, default_value_t = 15)]
     sse_keep_alive_secs: u64,
     /// HTTP session inactivity timeout in seconds (0 disables, but may leak
-    /// zombie sessions on silent disconnects). Defaults to 1800s in legacy
-    /// HTTP mode and 300s in pooled mode.
-    #[arg(long)]
-    session_keep_alive_secs: Option<u64>,
+    /// zombie sessions on silent disconnects). In pooled mode this is the
+    /// fallback for POST-only clients; SSE clients are reclaimed via
+    /// --worker-disconnect-grace-secs.
+    #[arg(long, default_value_t = DEFAULT_HTTP_SESSION_KEEP_ALIVE_SECS)]
+    session_keep_alive_secs: u64,
     /// Use stateless mode (POST only; no sessions)
     #[arg(long)]
     stateless: bool,
@@ -182,16 +182,6 @@ struct ServeHttpArgs {
     /// Grace period before pooled sessions are closed after a client stream disconnects.
     #[arg(long, default_value_t = 2)]
     worker_disconnect_grace_secs: u64,
-}
-
-fn effective_session_keep_alive_secs(args: &ServeHttpArgs) -> u64 {
-    args.session_keep_alive_secs.unwrap_or({
-        if args.max_workers > 1 {
-            POOLED_HTTP_SESSION_KEEP_ALIVE_SECS
-        } else {
-            LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS
-        }
-    })
 }
 
 #[derive(Args)]
@@ -475,7 +465,7 @@ fn run_server_http(
         .bind
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid bind address: {e}"))?;
-    let session_keep_alive_secs = effective_session_keep_alive_secs(&args);
+    let session_keep_alive_secs = args.session_keep_alive_secs;
 
     if args.max_workers > 1 {
         return run_server_http_pooled(
@@ -989,52 +979,19 @@ fn disasm_at(db: &IDB, addr: Address, count: usize) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        effective_session_keep_alive_secs, ServeHttpArgs, LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS,
-        POOLED_HTTP_SESSION_KEEP_ALIVE_SECS,
-    };
-
-    fn serve_http_args(max_workers: usize, session_keep_alive_secs: Option<u64>) -> ServeHttpArgs {
-        ServeHttpArgs {
-            bind: "127.0.0.1:8765".to_string(),
-            sse_keep_alive_secs: 15,
-            session_keep_alive_secs,
-            stateless: false,
-            json_response: false,
-            allow_origin: Vec::new(),
-            allow_host: None,
-            max_workers,
-            min_workers: 0,
-            worker_idle_timeout_secs: 300,
-            worker_op_timeout_secs: 600,
-            worker_disconnect_grace_secs: 2,
-        }
-    }
+    use crate::{Cli, DEFAULT_HTTP_SESSION_KEEP_ALIVE_SECS};
+    use clap::Parser;
 
     #[test]
-    fn legacy_http_keeps_long_session_default() {
-        let args = serve_http_args(1, None);
-
+    fn http_session_keep_alive_default_is_thirty_minutes() {
+        let cli = Cli::parse_from(["ida-mcp", "serve-http"]);
+        let crate::Command::ServeHttp(args) = cli.command.expect("subcommand") else {
+            panic!("expected serve-http")
+        };
         assert_eq!(
-            effective_session_keep_alive_secs(&args),
-            LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS
+            args.session_keep_alive_secs,
+            DEFAULT_HTTP_SESSION_KEEP_ALIVE_SECS
         );
-    }
-
-    #[test]
-    fn pooled_http_uses_shorter_session_default() {
-        let args = serve_http_args(2, None);
-
-        assert_eq!(
-            effective_session_keep_alive_secs(&args),
-            POOLED_HTTP_SESSION_KEEP_ALIVE_SECS
-        );
-    }
-
-    #[test]
-    fn explicit_session_keep_alive_overrides_mode_default() {
-        let args = serve_http_args(2, Some(1200));
-
-        assert_eq!(effective_session_keep_alive_secs(&args), 1200);
+        assert_eq!(DEFAULT_HTTP_SESSION_KEEP_ALIVE_SECS, 1800);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,17 @@ use axum::Router;
 use clap::{Args, Parser, Subcommand};
 use ida_mcp::server::http_access::{HttpAccessPolicy, HttpAccessService};
 use ida_mcp::server::http_config::{
-    build_session_manager, build_streamable_config, HttpServerOptions,
+    build_pooled_session_manager, build_session_manager, build_streamable_config, HttpServerOptions,
 };
 use ida_mcp::server::task::TaskRegistry;
 use ida_mcp::server::tool_filter::ToolFilter;
 use ida_mcp::server::SanitizedIdaServer;
 use ida_mcp::{
-    disasm::generate_disasm_line, expand_path, ida, DbInfo, FunctionInfo, IdaMcpServer, IdaWorker,
-    ServerMode,
+    disasm::generate_disasm_line,
+    expand_path, ida,
+    ida::pool::{PooledSessionState, WorkerPool, WorkerPoolConfig},
+    ida::worker::WorkerBackend,
+    DbInfo, FunctionInfo, IdaMcpServer, IdaWorker, ServerMode,
 };
 use idalib::{idb::IDBOpenOptions, Address, IDB};
 use rmcp::transport::stdio;
@@ -37,6 +40,8 @@ use tracing::{error, info, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 const REQUEST_QUEUE_CAPACITY: usize = 64;
+const LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS: u64 = 1800;
+const POOLED_HTTP_SESSION_KEEP_ALIVE_SECS: u64 = 300;
 
 #[derive(Parser)]
 #[command(name = "ida-mcp", version, about = "Headless IDA Pro MCP Server")]
@@ -53,6 +58,9 @@ enum Command {
     Serve,
     /// Run the MCP server over Streamable HTTP (SSE)
     ServeHttp(ServeHttpArgs),
+    /// Run a child worker for the HTTP process pool
+    #[command(hide = true)]
+    Worker(WorkerArgs),
     /// Run a direct CLI probe to exercise idalib
     Probe(ProbeArgs),
 }
@@ -106,6 +114,26 @@ impl ToolFilterArgs {
         )
         .map_err(|e| e.to_string())
     }
+
+    fn child_args(&self) -> Vec<OsString> {
+        let mut args = Vec::new();
+        if !self.toolsets.is_empty() {
+            args.push(OsString::from("--toolsets"));
+            args.push(OsString::from(self.toolsets.join(",")));
+        }
+        if !self.tools.is_empty() {
+            args.push(OsString::from("--tools"));
+            args.push(OsString::from(self.tools.join(",")));
+        }
+        if !self.exclude_tools.is_empty() {
+            args.push(OsString::from("--exclude-tools"));
+            args.push(OsString::from(self.exclude_tools.join(",")));
+        }
+        if self.read_only {
+            args.push(OsString::from("--read-only"));
+        }
+        args
+    }
 }
 
 #[derive(Args)]
@@ -117,10 +145,10 @@ struct ServeHttpArgs {
     #[arg(long, default_value_t = 15)]
     sse_keep_alive_secs: u64,
     /// HTTP session inactivity timeout in seconds (0 disables, but may leak
-    /// zombie sessions on silent disconnects). rmcp defaults to 300s, which
-    /// kills sessions during long IDA analyses; see issue #19.
-    #[arg(long, default_value_t = 1800)]
-    session_keep_alive_secs: u64,
+    /// zombie sessions on silent disconnects). Defaults to 1800s in legacy
+    /// HTTP mode and 300s in pooled mode.
+    #[arg(long)]
+    session_keep_alive_secs: Option<u64>,
     /// Use stateless mode (POST only; no sessions)
     #[arg(long)]
     stateless: bool,
@@ -139,7 +167,35 @@ struct ServeHttpArgs {
     /// Pass `*` or an empty value to disable the Host check.
     #[arg(long, value_delimiter = ',')]
     allow_host: Option<Vec<String>>,
+    /// Maximum child worker processes in pooled mode. 1 preserves legacy in-process HTTP behavior.
+    #[arg(long, default_value_t = 1)]
+    max_workers: usize,
+    /// Minimum idle child worker processes to keep warm in pooled mode.
+    #[arg(long, default_value_t = 0)]
+    min_workers: usize,
+    /// Seconds before an idle pooled worker is reaped (0 disables reaping).
+    #[arg(long, default_value_t = 300)]
+    worker_idle_timeout_secs: u64,
+    /// Per-child operation timeout in seconds; the parent kills a child that exceeds it.
+    #[arg(long, default_value_t = 600)]
+    worker_op_timeout_secs: u64,
+    /// Grace period before pooled sessions are closed after a client stream disconnects.
+    #[arg(long, default_value_t = 2)]
+    worker_disconnect_grace_secs: u64,
 }
+
+fn effective_session_keep_alive_secs(args: &ServeHttpArgs) -> u64 {
+    args.session_keep_alive_secs.unwrap_or({
+        if args.max_workers > 1 {
+            POOLED_HTTP_SESSION_KEEP_ALIVE_SECS
+        } else {
+            LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS
+        }
+    })
+}
+
+#[derive(Args)]
+struct WorkerArgs {}
 
 #[derive(Args)]
 struct ProbeArgs {
@@ -192,9 +248,11 @@ fn main() -> anyhow::Result<()> {
             .map(Arc::new)
             .map_err(|e| anyhow::anyhow!("invalid tool filter: {e}"))
     };
+    let child_filter_args = cli.filter.child_args();
     match cli.command.unwrap_or(Command::Serve) {
         Command::Serve => run_server(build_filter()?),
-        Command::ServeHttp(args) => run_server_http(args, build_filter()?),
+        Command::ServeHttp(args) => run_server_http(args, build_filter()?, child_filter_args),
+        Command::Worker(_args) => run_server_with_mode(build_filter()?, ServerMode::Worker),
         Command::Probe(args) => run_probe(args),
     }
 }
@@ -250,16 +308,21 @@ fn cancel_background_tasks(registry: &TaskRegistry, message: &str) {
 }
 
 fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
-    info!("Starting IDA MCP Server (server mode)");
+    run_server_with_mode(filter, ServerMode::Stdio)
+}
+
+fn run_server_with_mode(filter: Arc<ToolFilter>, mode: ServerMode) -> anyhow::Result<()> {
+    info!(?mode, "Starting IDA MCP Server (stdio transport)");
     let init_state = init_stdio_ida_state()?;
 
     // Create channel for IDA requests
     let (tx, rx) = mpsc::sync_channel(REQUEST_QUEUE_CAPACITY);
     let worker = IdaWorker::new(tx);
+    let backend = WorkerBackend::local(Arc::new(worker.clone()));
 
     // Spawn background thread for tokio runtime and MCP server
-    let worker_for_server = worker.clone();
-    let worker_for_shutdown = worker.clone();
+    let worker_for_server = backend.clone();
+    let worker_for_shutdown = backend.clone();
     let filter_for_server = filter.clone();
     let server_handle = thread::spawn(move || {
         // Create tokio runtime on this background thread
@@ -271,8 +334,8 @@ fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
         rt.block_on(async move {
             info!("MCP server listening on stdio");
             let server = IdaMcpServer::with_filter(
-                Arc::new(worker_for_server),
-                ServerMode::Stdio,
+                worker_for_server,
+                mode,
                 filter_for_server.clone(),
             );
             let task_registry = server.task_registry().clone();
@@ -378,23 +441,64 @@ fn run_server(filter: Arc<ToolFilter>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_server_http(args: ServeHttpArgs, filter: Arc<ToolFilter>) -> anyhow::Result<()> {
+fn run_server_http(
+    args: ServeHttpArgs,
+    filter: Arc<ToolFilter>,
+    child_filter_args: Vec<OsString>,
+) -> anyhow::Result<()> {
     info!("Starting IDA MCP Server (streamable HTTP mode)");
-    let init_state = ida::IdaInitState::deferred();
     if args.json_response && !args.stateless {
         info!("--json-response is ignored unless --stateless is also set");
+    }
+    if args.max_workers == 0 {
+        return Err(anyhow::anyhow!("--max-workers must be at least 1"));
+    }
+    if args.min_workers > args.max_workers {
+        return Err(anyhow::anyhow!(
+            "--min-workers ({}) cannot exceed --max-workers ({})",
+            args.min_workers,
+            args.max_workers
+        ));
+    }
+    if args.max_workers > 1 && args.stateless {
+        return Err(anyhow::anyhow!(
+            "--max-workers > 1 requires stateful HTTP sessions; remove --stateless"
+        ));
+    }
+    if args.worker_op_timeout_secs == 0 {
+        return Err(anyhow::anyhow!(
+            "--worker-op-timeout-secs must be at least 1"
+        ));
     }
 
     let bind_addr: SocketAddr = args
         .bind
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid bind address: {e}"))?;
+    let session_keep_alive_secs = effective_session_keep_alive_secs(&args);
 
+    if args.max_workers > 1 {
+        return run_server_http_pooled(
+            args,
+            filter,
+            child_filter_args,
+            bind_addr,
+            session_keep_alive_secs,
+        );
+    }
+
+    info!(
+        "HTTP worker pool disabled (max_workers=1); HTTP sessions share one IDA context. \
+         Pass --max-workers N where N > 1 for concurrent multi-IDB analysis."
+    );
+
+    let init_state = ida::IdaInitState::deferred();
     let (tx, rx) = mpsc::sync_channel(REQUEST_QUEUE_CAPACITY);
     let worker = Arc::new(IdaWorker::new(tx));
+    let backend = WorkerBackend::local(worker.clone());
 
-    let worker_for_factory = worker.clone();
-    let worker_for_shutdown = worker.clone();
+    let worker_for_factory = backend.clone();
+    let worker_for_shutdown = backend.clone();
     let filter_for_factory = filter.clone();
     let server_handle = thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_multi_thread()
@@ -423,7 +527,7 @@ fn run_server_http(args: ServeHttpArgs, filter: Arc<ToolFilter>) -> anyhow::Resu
             );
             info!("HTTP Host guard: {}", access_policy.host_policy_summary());
 
-            let session_manager = build_session_manager(args.session_keep_alive_secs);
+            let session_manager = build_session_manager(session_keep_alive_secs);
             let cancel = tokio_util::sync::CancellationToken::new();
             let config = build_streamable_config(
                 HttpServerOptions {
@@ -489,6 +593,139 @@ fn run_server_http(args: ServeHttpArgs, filter: Arc<ToolFilter>) -> anyhow::Resu
     }
 
     info!("Server stopped");
+    Ok(())
+}
+
+fn run_server_http_pooled(
+    args: ServeHttpArgs,
+    filter: Arc<ToolFilter>,
+    child_filter_args: Vec<OsString>,
+    bind_addr: SocketAddr,
+    session_keep_alive_secs: u64,
+) -> anyhow::Result<()> {
+    info!(
+        max_workers = args.max_workers,
+        min_workers = args.min_workers,
+        "Starting pooled HTTP router; parent will not initialize IDA"
+    );
+    let server_handle = thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                error!("Failed to create tokio runtime: {e}");
+                return;
+            }
+        };
+
+        let result = rt.block_on(async move {
+            let listener = tokio::net::TcpListener::bind(bind_addr)
+                .await
+                .map_err(|e| anyhow::anyhow!("bind failed: {e}"))?;
+            let listen_addr = listener
+                .local_addr()
+                .map_err(|e| anyhow::anyhow!("failed to read listener address: {e}"))?;
+
+            let access_policy = HttpAccessPolicy::from_cli(
+                listen_addr,
+                &args.allow_origin,
+                args.allow_host.as_deref(),
+            );
+            info!("HTTP Host guard: {}", access_policy.host_policy_summary());
+
+            let exe_path = std::env::current_exe()
+                .map_err(|e| anyhow::anyhow!("failed to resolve current executable: {e}"))?;
+            let pool = WorkerPool::new(WorkerPoolConfig {
+                max_workers: args.max_workers,
+                min_workers: args.min_workers,
+                worker_idle_timeout: Duration::from_secs(args.worker_idle_timeout_secs),
+                worker_op_timeout: Duration::from_secs(args.worker_op_timeout_secs),
+                exe_path,
+                filter_args: child_filter_args,
+            });
+            pool.warm_min()
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to warm worker pool: {e}"))?;
+
+            let session_manager = build_pooled_session_manager(
+                session_keep_alive_secs,
+                Duration::from_secs(args.worker_disconnect_grace_secs),
+            );
+            info!(
+                session_keep_alive_secs,
+                worker_disconnect_grace_secs = args.worker_disconnect_grace_secs,
+                "Using disconnect-aware pooled HTTP session manager"
+            );
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let config = build_streamable_config(
+                HttpServerOptions {
+                    sse_keep_alive_secs: args.sse_keep_alive_secs,
+                    stateless: args.stateless,
+                    json_response: args.json_response,
+                },
+                cancel.clone(),
+            );
+
+            let pool_for_factory = pool.clone();
+            let filter_for_factory = filter.clone();
+            let service = StreamableHttpService::new(
+                move || {
+                    let pooled_state = Arc::new(PooledSessionState::new(
+                        pool_for_factory.clone(),
+                        uuid::Uuid::new_v4().to_string(),
+                    ));
+                    let inner = IdaMcpServer::with_filter(
+                        WorkerBackend::pooled(pooled_state),
+                        ServerMode::Http,
+                        filter_for_factory.clone(),
+                    );
+                    Ok(SanitizedIdaServer::with_filter(
+                        inner,
+                        filter_for_factory.clone(),
+                    ))
+                },
+                session_manager,
+                config,
+            );
+            let service = HttpAccessService::new(service, access_policy);
+
+            let router = Router::new().route_service("/", service);
+            info!("MCP pooled HTTP server listening on http://{listen_addr}");
+
+            let cancel_for_shutdown = cancel.clone();
+            let pool_for_shutdown = pool.clone();
+            tokio::spawn(async move {
+                if wait_for_shutdown_signal().await.is_ok() {
+                    info!("Shutdown signal received");
+                    cancel_for_shutdown.cancel();
+                    pool_for_shutdown.shutdown_all().await;
+                }
+            });
+
+            let cancel_for_serve = cancel.clone();
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    cancel_for_serve.cancelled().await;
+                    info!("Pooled HTTP server shutting down");
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("serve failed: {e}"))?;
+
+            pool.shutdown_all().await;
+            Ok::<_, anyhow::Error>(())
+        });
+        if let Err(err) = result {
+            error!("HTTP server error: {err}");
+        }
+    });
+
+    if let Err(e) = server_handle.join() {
+        error!("Server thread panicked: {:?}", e);
+    }
+
+    info!("Pooled HTTP server stopped");
     Ok(())
 }
 
@@ -748,4 +985,56 @@ fn disasm_at(db: &IDB, addr: Address, count: usize) -> anyhow::Result<String> {
     }
 
     Ok(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        effective_session_keep_alive_secs, ServeHttpArgs, LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS,
+        POOLED_HTTP_SESSION_KEEP_ALIVE_SECS,
+    };
+
+    fn serve_http_args(max_workers: usize, session_keep_alive_secs: Option<u64>) -> ServeHttpArgs {
+        ServeHttpArgs {
+            bind: "127.0.0.1:8765".to_string(),
+            sse_keep_alive_secs: 15,
+            session_keep_alive_secs,
+            stateless: false,
+            json_response: false,
+            allow_origin: Vec::new(),
+            allow_host: None,
+            max_workers,
+            min_workers: 0,
+            worker_idle_timeout_secs: 300,
+            worker_op_timeout_secs: 600,
+            worker_disconnect_grace_secs: 2,
+        }
+    }
+
+    #[test]
+    fn legacy_http_keeps_long_session_default() {
+        let args = serve_http_args(1, None);
+
+        assert_eq!(
+            effective_session_keep_alive_secs(&args),
+            LEGACY_HTTP_SESSION_KEEP_ALIVE_SECS
+        );
+    }
+
+    #[test]
+    fn pooled_http_uses_shorter_session_default() {
+        let args = serve_http_args(2, None);
+
+        assert_eq!(
+            effective_session_keep_alive_secs(&args),
+            POOLED_HTTP_SESSION_KEEP_ALIVE_SECS
+        );
+    }
+
+    #[test]
+    fn explicit_session_keep_alive_overrides_mode_default() {
+        let args = serve_http_args(2, Some(1200));
+
+        assert_eq!(effective_session_keep_alive_secs(&args), 1200);
+    }
 }

--- a/src/server/http_config.rs
+++ b/src/server/http_config.rs
@@ -1,8 +1,16 @@
 //! Builds the rmcp Streamable HTTP transport configuration.
 
-use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use futures_util::Stream;
+use rmcp::model::ClientJsonRpcMessage;
+use rmcp::transport::streamable_http_server::session::{
+    local::{LocalSessionManager, LocalSessionManagerError},
+    RestoreOutcome, ServerSseMessage, SessionId, SessionManager,
+};
 use rmcp::transport::streamable_http_server::StreamableHttpServerConfig;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
@@ -16,6 +24,16 @@ pub struct HttpServerOptions {
     pub json_response: bool,
 }
 
+fn session_manager_with_keep_alive(session_keep_alive_secs: u64) -> LocalSessionManager {
+    let mut manager = LocalSessionManager::default();
+    manager.session_config.keep_alive = if session_keep_alive_secs == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(session_keep_alive_secs))
+    };
+    manager
+}
+
 /// Build an `Arc<LocalSessionManager>` with a session-inactivity timeout.
 ///
 /// rmcp defaults to 5 minutes, which is too short for long-running IDA
@@ -26,14 +44,288 @@ pub struct HttpServerOptions {
 /// sessions when HTTP connections drop silently (e.g. HTTP/2 `RST_STREAM`),
 /// so prefer a generous positive value over disabling.
 pub fn build_session_manager(session_keep_alive_secs: u64) -> Arc<LocalSessionManager> {
-    // rmcp 1.5 exposes no builder for SessionConfig; mutate the public field.
-    let mut manager = LocalSessionManager::default();
-    manager.session_config.keep_alive = if session_keep_alive_secs == 0 {
-        None
-    } else {
-        Some(Duration::from_secs(session_keep_alive_secs))
-    };
-    Arc::new(manager)
+    Arc::new(session_manager_with_keep_alive(session_keep_alive_secs))
+}
+
+/// Build a pooled-mode session manager that closes abandoned HTTP sessions when
+/// the client drops its standalone SSE stream without sending an explicit HTTP
+/// DELETE. POST-only clients fall back to the session keep-alive timeout.
+pub fn build_pooled_session_manager(
+    session_keep_alive_secs: u64,
+    disconnect_grace: Duration,
+) -> Arc<PooledSessionManager> {
+    let inner = Arc::new(session_manager_with_keep_alive(session_keep_alive_secs));
+    Arc::new(PooledSessionManager::new(inner, disconnect_grace))
+}
+
+#[derive(Debug, Clone)]
+pub struct PooledSessionManager {
+    inner: Arc<LocalSessionManager>,
+    disconnects: Arc<SessionDisconnectRegistry>,
+}
+
+impl PooledSessionManager {
+    fn new(inner: Arc<LocalSessionManager>, disconnect_grace: Duration) -> Self {
+        Self {
+            inner: inner.clone(),
+            disconnects: Arc::new(SessionDisconnectRegistry::new(inner, disconnect_grace)),
+        }
+    }
+}
+
+impl SessionManager for PooledSessionManager {
+    type Error = LocalSessionManagerError;
+    type Transport = <LocalSessionManager as SessionManager>::Transport;
+
+    async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
+        self.inner.create_session().await
+    }
+
+    async fn initialize_session(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<rmcp::model::ServerJsonRpcMessage, Self::Error> {
+        self.inner.initialize_session(id, message).await
+    }
+
+    async fn has_session(&self, id: &SessionId) -> Result<bool, Self::Error> {
+        self.inner.has_session(id).await
+    }
+
+    async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+        self.inner.close_session(id).await?;
+        self.disconnects.session_closed(id);
+        Ok(())
+    }
+
+    async fn create_stream(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        let stream = self.inner.create_stream(id, message).await?;
+        let guard = self.disconnects.stream_opened(id);
+        // A dropped POST response stream is not sufficient proof that the
+        // session is gone; POST-only clients rely on the keep-alive timeout as
+        // their final cleanup safety net.
+        Ok(TrackedSessionStream::new(stream, guard, false))
+    }
+
+    async fn accept_message(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<(), Self::Error> {
+        self.inner.accept_message(id, message).await
+    }
+
+    async fn create_standalone_stream(
+        &self,
+        id: &SessionId,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        let stream = self.inner.create_standalone_stream(id).await?;
+        let guard = self.disconnects.stream_opened(id);
+        Ok(TrackedSessionStream::new(stream, guard, true))
+    }
+
+    async fn resume(
+        &self,
+        id: &SessionId,
+        last_event_id: String,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        // rmcp 1.7 local::EventId formats request-scoped streams as
+        // "<index>/<request_id>" and standalone streams as "<index>".
+        let close_on_drop = !last_event_id.contains('/');
+        let stream = self.inner.resume(id, last_event_id).await?;
+        let guard = self.disconnects.stream_opened(id);
+        Ok(TrackedSessionStream::new(stream, guard, close_on_drop))
+    }
+
+    async fn restore_session(
+        &self,
+        id: SessionId,
+    ) -> Result<RestoreOutcome<Self::Transport>, Self::Error> {
+        self.inner.restore_session(id).await
+    }
+}
+
+#[derive(Debug)]
+struct SessionDisconnectRegistry {
+    inner: Arc<LocalSessionManager>,
+    disconnect_grace: Duration,
+    states: Mutex<HashMap<SessionId, SessionDisconnectState>>,
+}
+
+#[derive(Debug, Default)]
+struct SessionDisconnectState {
+    generation: u64,
+    active_streams: usize,
+    abandoned_generation: Option<u64>,
+}
+
+impl SessionDisconnectRegistry {
+    fn new(inner: Arc<LocalSessionManager>, disconnect_grace: Duration) -> Self {
+        Self {
+            inner,
+            disconnect_grace,
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn stream_opened(self: &Arc<Self>, session_id: &SessionId) -> SessionStreamGuard {
+        let generation = match self.states.lock() {
+            Ok(mut states) => {
+                let state = states.entry(session_id.clone()).or_default();
+                state.generation = state.generation.wrapping_add(1);
+                state.active_streams = state.active_streams.saturating_add(1);
+                state.abandoned_generation = None;
+                state.generation
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "pooled session disconnect state is poisoned");
+                0
+            }
+        };
+        SessionStreamGuard {
+            registry: self.clone(),
+            session_id: session_id.clone(),
+            generation,
+        }
+    }
+
+    fn session_closed(&self, session_id: &SessionId) {
+        match self.states.lock() {
+            Ok(mut states) => {
+                states.remove(session_id);
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "pooled session disconnect state is poisoned");
+            }
+        }
+    }
+
+    fn stream_closed(self: Arc<Self>, session_id: SessionId, generation: u64, abandoned: bool) {
+        let close_generation = match self.states.lock() {
+            Ok(mut states) => {
+                let Some(state) = states.get_mut(&session_id) else {
+                    return;
+                };
+                state.active_streams = state.active_streams.saturating_sub(1);
+                if abandoned {
+                    state.abandoned_generation = Some(generation);
+                }
+                if state.active_streams == 0 {
+                    state.abandoned_generation
+                } else {
+                    None
+                }
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "pooled session disconnect state is poisoned");
+                None
+            }
+        };
+        let Some(close_generation) = close_generation else {
+            return;
+        };
+
+        tokio::spawn(async move {
+            if !self.disconnect_grace.is_zero() {
+                tokio::time::sleep(self.disconnect_grace).await;
+            }
+            if !self.should_close(&session_id, close_generation) {
+                return;
+            }
+            tracing::info!(
+                session_id = session_id.as_ref(),
+                "closing pooled HTTP session after client stream disconnect"
+            );
+            match self.inner.close_session(&session_id).await {
+                Ok(()) => self.session_closed(&session_id),
+                Err(err) => {
+                    tracing::warn!(
+                        session_id = session_id.as_ref(),
+                        error = %err,
+                        "failed to close pooled HTTP session after client stream disconnect"
+                    );
+                }
+            }
+        });
+    }
+
+    fn should_close(&self, session_id: &SessionId, generation: u64) -> bool {
+        match self.states.lock() {
+            Ok(states) => states.get(session_id).is_some_and(|state| {
+                state.abandoned_generation == Some(generation) && state.active_streams == 0
+            }),
+            Err(err) => {
+                tracing::warn!(error = %err, "pooled session disconnect state is poisoned");
+                false
+            }
+        }
+    }
+}
+
+struct SessionStreamGuard {
+    registry: Arc<SessionDisconnectRegistry>,
+    session_id: SessionId,
+    generation: u64,
+}
+
+impl SessionStreamGuard {
+    fn finish(self, abandoned: bool) {
+        self.registry
+            .stream_closed(self.session_id, self.generation, abandoned);
+    }
+}
+
+struct TrackedSessionStream<S> {
+    inner: Pin<Box<S>>,
+    guard: Option<SessionStreamGuard>,
+    close_on_drop: bool,
+}
+
+impl<S> TrackedSessionStream<S> {
+    fn new(stream: S, guard: SessionStreamGuard, close_on_drop: bool) -> Self {
+        Self {
+            inner: Box::pin(stream),
+            guard: Some(guard),
+            close_on_drop,
+        }
+    }
+
+    fn finish(&mut self, abandoned: bool) {
+        if let Some(guard) = self.guard.take() {
+            guard.finish(abandoned);
+        }
+    }
+}
+
+impl<S> Unpin for TrackedSessionStream<S> {}
+
+impl<S> Stream for TrackedSessionStream<S>
+where
+    S: Stream<Item = ServerSseMessage>,
+{
+    type Item = ServerSseMessage;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(None) => {
+                this.finish(false);
+                Poll::Ready(None)
+            }
+            other => other,
+        }
+    }
+}
+
+impl<S> Drop for TrackedSessionStream<S> {
+    fn drop(&mut self) {
+        self.finish(self.close_on_drop);
+    }
 }
 
 pub fn build_streamable_config(
@@ -59,7 +351,10 @@ pub fn build_streamable_config(
 mod tests {
     use crate::server::http_config::{
         build_session_manager, build_streamable_config, HttpServerOptions,
+        SessionDisconnectRegistry,
     };
+    use rmcp::transport::streamable_http_server::session::{local::LocalSessionManager, SessionId};
+    use std::sync::Arc;
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
 
@@ -110,5 +405,47 @@ mod tests {
             Some(Duration::from_secs(1800)),
             "explicit value must override rmcp's 300s default that killed long IDA calls"
         );
+    }
+
+    #[tokio::test]
+    async fn pooled_disconnect_registry_closes_abandoned_stream_after_grace() {
+        let registry = Arc::new(SessionDisconnectRegistry::new(
+            Arc::new(LocalSessionManager::default()),
+            Duration::ZERO,
+        ));
+        let session_id: SessionId = "session-a".to_string().into();
+
+        let guard = registry.stream_opened(&session_id);
+        guard.finish(true);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let states = registry.states.lock().unwrap();
+        assert!(!states.contains_key(&session_id));
+    }
+
+    #[tokio::test]
+    async fn pooled_disconnect_registry_reconnect_cancels_abandoned_close() {
+        let registry = Arc::new(SessionDisconnectRegistry::new(
+            Arc::new(LocalSessionManager::default()),
+            Duration::from_millis(50),
+        ));
+        let session_id: SessionId = "session-b".to_string().into();
+
+        let abandoned = registry.stream_opened(&session_id);
+        abandoned.finish(true);
+        let reconnected = registry.stream_opened(&session_id);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let states = registry.states.lock().unwrap();
+        let state = states.get(&session_id).unwrap();
+        assert_eq!(state.active_streams, 1);
+        assert!(state.abandoned_generation.is_none());
+        drop(states);
+
+        reconnected.finish(false);
+        let states = registry.states.lock().unwrap();
+        let state = states.get(&session_id).unwrap();
+        assert_eq!(state.active_streams, 0);
+        assert!(state.abandoned_generation.is_none());
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,8 +11,9 @@ pub use requests::*;
 
 use crate::error::ToolError;
 use crate::ida::observability::{ProgressReceiver, ProgressSender};
-use crate::ida::worker::{CloseAuthorization, CloseTokenGrant, MAX_TIMEOUT_SECS};
-use crate::ida::IdaWorker;
+use crate::ida::worker::{
+    CloseAuthorization, CloseTokenGrant, IdaWorker, WorkerBackend, MAX_TIMEOUT_SECS,
+};
 use crate::server::operation::{
     next_operation_id, OperationRegistry, OperationSnapshot, RecentOperations,
 };
@@ -24,6 +25,7 @@ use rmcp::{
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
 use serde_json::{json, Map, Value};
+use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,7 +34,7 @@ use tracing::{debug, info, instrument, warn};
 /// MCP server for IDA Pro analysis
 #[derive(Clone)]
 pub struct IdaMcpServer {
-    worker: Arc<IdaWorker>,
+    worker: WorkerBackend,
     tool_mux: ToolMux<IdaMcpServer>,
     mode: ServerMode,
     task_registry: task::TaskRegistry,
@@ -50,6 +52,7 @@ pub struct IdaMcpServer {
 pub enum ServerMode {
     Stdio,
     Http,
+    Worker,
 }
 
 #[derive(Clone)]
@@ -108,6 +111,16 @@ const OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES: u64 = 50 * 1024 * 1024;
 /// Bound the MCP elicitation prompt separately from IDA work. If the client
 /// leaves the prompt unanswered, default to background analysis.
 const OPEN_IDB_ELICITATION_TIMEOUT_SECS: u64 = 30;
+/// Give foreground operations a short window to observe cancellation and clean
+/// up owned resources before the MCP timeout/cancel response is returned.
+const FOREGROUND_CANCEL_CLEANUP_TIMEOUT_SECS: u64 = 6;
+
+fn pretty_json(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|err| {
+        warn!(error = %err, "failed to pretty-print JSON response");
+        value.to_string()
+    })
+}
 
 enum ForegroundOperationError {
     Tool(ToolError),
@@ -123,14 +136,14 @@ enum ForegroundOperationError {
 impl IdaMcpServer {
     pub fn new(worker: Arc<IdaWorker>, mode: ServerMode) -> Self {
         Self::with_filter(
-            worker,
+            WorkerBackend::local(worker),
             mode,
             Arc::new(tool_filter::ToolFilter::unrestricted()),
         )
     }
 
     pub fn with_filter(
-        worker: Arc<IdaWorker>,
+        worker: WorkerBackend,
         mode: ServerMode,
         filter: Arc<tool_filter::ToolFilter>,
     ) -> Self {
@@ -163,12 +176,15 @@ impl IdaMcpServer {
     }
 
     fn close_hint(&self) -> &'static str {
-        close_hint_for(self.mode)
+        close_hint_for(self.mode, self.worker.is_pooled())
     }
 
     fn http_close_grant(&self) -> Option<Result<CloseTokenGrant, String>> {
-        matches!(self.mode, ServerMode::Http)
-            .then(|| self.worker.issue_close_token_for_session(&self.session_id))
+        if matches!(self.mode, ServerMode::Http) && self.worker.uses_close_tokens() {
+            self.worker.issue_close_token_for_session(&self.session_id)
+        } else {
+            None
+        }
     }
 
     fn apply_close_metadata(
@@ -421,6 +437,26 @@ impl IdaMcpServer {
         next_operation_id(self.operation_nonce.as_ref())
     }
 
+    async fn finish_cancelled_foreground<T, Fut>(
+        tool_name: &'static str,
+        operation_fut: Pin<&mut Fut>,
+    ) where
+        Fut: std::future::Future<Output = Result<T, ToolError>>,
+    {
+        let cleanup = tokio::time::timeout(
+            Duration::from_secs(FOREGROUND_CANCEL_CLEANUP_TIMEOUT_SECS),
+            operation_fut,
+        )
+        .await;
+        if cleanup.is_err() {
+            warn!(
+                tool_name,
+                timeout_secs = FOREGROUND_CANCEL_CLEANUP_TIMEOUT_SECS,
+                "foreground operation did not finish cancellation cleanup before response"
+            );
+        }
+    }
+
     async fn run_foreground_operation<T, F, Fut>(
         &self,
         ctx: &RequestContext<RoleServer>,
@@ -517,6 +553,7 @@ impl IdaMcpServer {
                 }
             }
             Outcome::TimedOut(timeout_secs) => {
+                Self::finish_cancelled_foreground(tool_name, operation_fut.as_mut()).await;
                 drain_task.abort();
                 let _ = drain_task.await;
                 let snapshot = self
@@ -541,6 +578,7 @@ impl IdaMcpServer {
                 })
             }
             Outcome::Cancelled => {
+                Self::finish_cancelled_foreground(tool_name, operation_fut.as_mut()).await;
                 drain_task.abort();
                 let _ = drain_task.await;
                 let snapshot = self
@@ -648,7 +686,9 @@ impl IdaMcpServer {
             if !frameworks.is_empty() {
                 map.insert("frameworks_loaded".to_string(), json!(frameworks));
             }
-            self.apply_close_metadata(map, close_token);
+            if !matches!(self.mode, ServerMode::Worker) {
+                self.apply_close_metadata(map, close_token);
+            }
         }
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -660,7 +700,7 @@ impl IdaMcpServer {
     async fn run_dsc_background(
         task_id: String,
         registry: task::TaskRegistry,
-        worker: Arc<IdaWorker>,
+        worker: WorkerBackend,
         mode: ServerMode,
         ctx: DscBackgroundCtx,
     ) {
@@ -763,7 +803,7 @@ impl IdaMcpServer {
 
         let close_token = match (mode, owner_session_id.as_deref()) {
             (ServerMode::Http, Some(owner_session_id)) => {
-                Some(worker.issue_close_token_for_session(owner_session_id))
+                worker.issue_close_token_for_session(owner_session_id)
             }
             _ => None,
         };
@@ -775,7 +815,7 @@ impl IdaMcpServer {
             if !frameworks.is_empty() {
                 map.insert("frameworks_loaded".to_string(), json!(frameworks));
             }
-            apply_close_metadata(map, close_token, close_hint_for(mode));
+            apply_close_metadata(map, close_token, close_hint_for(mode, worker.is_pooled()));
         }
 
         info!(task_id = %task_id, "DSC background task completed");
@@ -816,10 +856,12 @@ macro_rules! try_param {
     };
 }
 
-fn close_hint_for(mode: ServerMode) -> &'static str {
-    match mode {
-        ServerMode::Stdio => "Call close_idb when done to release locks for other sessions.",
-        ServerMode::Http => "In multi-client (HTTP/SSE) mode, close_idb accepts the close_token returned by open_idb. The owning session can also close without re-sending the token, and close_idb(force=true) can recover from a lost session.",
+fn close_hint_for(mode: ServerMode, pooled: bool) -> &'static str {
+    match (mode, pooled) {
+        (ServerMode::Http, true) => "In pooled HTTP/SSE mode, close_idb releases this session's child worker lease. Sessions do not share one global close_token.",
+        (ServerMode::Stdio, _) => "Call close_idb when done to release locks for other sessions.",
+        (ServerMode::Http, false) => "In multi-client (HTTP/SSE) mode, close_idb accepts the close_token returned by open_idb. The owning session can also close without re-sending the token, and close_idb(force=true) can recover from a lost session.",
+        (ServerMode::Worker, _) => "Child worker mode is managed by the parent router; close_idb is normally called by the parent.",
     }
 }
 
@@ -899,7 +941,10 @@ impl IdaMcpServer {
         ));
 
         let user_auto_analyse = req.auto_analyse.unwrap_or(false);
-        let large_input_size = if user_auto_analyse && !Self::is_database_path(&path) {
+        let large_input_size = if !matches!(self.mode, ServerMode::Worker)
+            && user_auto_analyse
+            && !Self::is_database_path(&path)
+        {
             Self::input_size_above_threshold(&path)
         } else {
             None
@@ -972,8 +1017,10 @@ impl IdaMcpServer {
                         quick_tools.extend(["decompile", "xrefs_to"]);
                     }
                     map.insert("quick_tools".to_string(), json!(quick_tools));
-                    map.insert("session_id".to_string(), json!(self.session_id));
-                    self.apply_close_metadata(map, close_token);
+                    if !matches!(self.mode, ServerMode::Worker) {
+                        map.insert("session_id".to_string(), json!(self.session_id));
+                        self.apply_close_metadata(map, close_token);
+                    }
                     if let Some((task_id, status)) = analysis_task {
                         let reason = format!(
                             "Input size exceeded {} MiB; auto-analysis routed to a background task. Poll task_status(task_id) for progress.",
@@ -1150,8 +1197,10 @@ impl IdaMcpServer {
             Ok(status) => {
                 let mut value =
                     serde_json::to_value(&status).unwrap_or_else(|_| json!(format!("{status:?}")));
-                if let Value::Object(map) = &mut value {
-                    map.insert("session_id".to_string(), json!(self.session_id));
+                if !matches!(self.mode, ServerMode::Worker) {
+                    if let Value::Object(map) = &mut value {
+                        map.insert("session_id".to_string(), json!(self.session_id));
+                    }
                 }
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&value).unwrap_or_else(|_| format!("{status:?}")),
@@ -1172,7 +1221,7 @@ impl IdaMcpServer {
         Parameters(req): Parameters<CloseIdbRequest>,
     ) -> Result<CallToolResult, McpError> {
         info!("Tool call: close_idb received");
-        if matches!(self.mode, ServerMode::Http) {
+        if matches!(self.mode, ServerMode::Http) && self.worker.uses_close_tokens() {
             match self.worker.authorize_close(
                 &self.session_id,
                 req.token.as_deref(),
@@ -1251,9 +1300,9 @@ impl IdaMcpServer {
                 if filtering_active {
                     payload["filtering_active"] = json!(true);
                 }
-                return Ok(CallToolResult::success(vec![Content::text(
-                    serde_json::to_string_pretty(&payload).unwrap(),
-                )]));
+                return Ok(CallToolResult::success(vec![Content::text(pretty_json(
+                    &payload,
+                ))]));
             }
         }
 
@@ -1282,9 +1331,9 @@ impl IdaMcpServer {
             if filtering_active {
                 payload["filtering_active"] = json!(true);
             }
-            return Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&payload).unwrap(),
-            )]));
+            return Ok(CallToolResult::success(vec![Content::text(pretty_json(
+                &payload,
+            ))]));
         }
 
         // No query or category - list all categories. Counts reflect enabled
@@ -1318,9 +1367,9 @@ impl IdaMcpServer {
             payload["enabled_tool_count"] = json!(filter.enabled_count());
         }
 
-        Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&payload).unwrap(),
-        )]))
+        Ok(CallToolResult::success(vec![Content::text(pretty_json(
+            &payload,
+        ))]))
     }
 
     #[tool(
@@ -1339,8 +1388,8 @@ impl IdaMcpServer {
             && tool_registry::get_tool(&req.name).is_some()
             && !self.filter.is_enabled(&req.name)
         {
-            return Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&json!({
+            return Ok(CallToolResult::success(vec![Content::text(pretty_json(
+                &json!({
                     "error": format!(
                         "tool '{}' is disabled by current filter \
                          (--toolsets/--tools/--exclude-tools/--read-only)",
@@ -1348,37 +1397,34 @@ impl IdaMcpServer {
                     ),
                     "filtering_active": true,
                     "hint": "call tool_catalog to see enabled tools",
-                }))
-                .unwrap(),
-            )]));
+                }),
+            ))]));
         }
 
         if let Some(tool) = tool_registry::get_tool(&req.name) {
             let params = tool_params_schema(&req.name);
-            Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&json!({
+            Ok(CallToolResult::success(vec![Content::text(pretty_json(
+                &json!({
                     "name": tool.name,
                     "category": tool.category.as_str(),
                     "description": tool.full_desc,
                     "parameters": params,
                     "example": tool.example,
                     "keywords": tool.keywords,
-                }))
-                .unwrap(),
-            )]))
+                }),
+            ))]))
         } else {
             // Suggest similar tools
             let suggestions = tool_registry::search_tools(&req.name, 3);
             let suggestion_names: Vec<_> = suggestions.iter().map(|(t, _)| t.name).collect();
 
-            Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&json!({
+            Ok(CallToolResult::success(vec![Content::text(pretty_json(
+                &json!({
                     "error": format!("Tool '{}' not found", req.name),
                     "suggestions": suggestion_names,
                     "hint": "Use tool_catalog to discover available tools"
-                }))
-                .unwrap(),
-            )]))
+                }),
+            ))]))
         }
     }
 
@@ -2130,8 +2176,10 @@ impl IdaMcpServer {
             Ok(result) => {
                 let mut value =
                     serde_json::to_value(&result).unwrap_or_else(|_| json!(format!("{result:?}")));
-                if let Value::Object(map) = &mut value {
-                    map.insert("session_id".to_string(), json!(self.session_id));
+                if !matches!(self.mode, ServerMode::Worker) {
+                    if let Value::Object(map) = &mut value {
+                        map.insert("session_id".to_string(), json!(self.session_id));
+                    }
                 }
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&value).unwrap_or_else(|_| format!("{result:?}")),
@@ -3214,7 +3262,7 @@ impl IdaMcpServer {
         info!(task_id = %task_id, "Spawning background auto-analysis");
 
         let registry = self.task_registry.clone();
-        let worker = Arc::clone(&self.worker);
+        let worker = self.worker.clone();
         let tid = task_id.clone();
         let cancel_token = tokio_util::sync::CancellationToken::new();
         let worker_cancel_token = cancel_token.clone();
@@ -3409,7 +3457,7 @@ impl IdaMcpServer {
         );
 
         let registry = self.task_registry.clone();
-        let worker = Arc::clone(&self.worker);
+        let worker = self.worker.clone();
         let mode = self.mode;
         let module = req.module.clone();
         let tid = task_id.clone();
@@ -3905,7 +3953,7 @@ fn dsc_analysis_next_steps(
 }
 
 async fn get_int_values(
-    worker: &IdaWorker,
+    worker: &WorkerBackend,
     address: Value,
     size: usize,
 ) -> Result<CallToolResult, McpError> {
@@ -4579,6 +4627,7 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
 
 #[cfg(test)]
 mod tests {
+    use crate::error::ToolError;
     use crate::ida::worker::CloseTokenGrant;
     use crate::server::{
         apply_close_metadata, close_hint_for, normalize_schema_value,
@@ -4590,6 +4639,7 @@ mod tests {
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
     use serde_json::{json, Value};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{mpsc, Arc};
 
     fn test_server() -> IdaMcpServer {
@@ -4705,6 +4755,24 @@ mod tests {
         assert!(message.contains("Last known phase: opening"));
         assert!(message.contains("Operation id: fg-1"));
         assert!(message.contains("detail"));
+    }
+
+    #[tokio::test]
+    async fn foreground_cancel_cleanup_polls_cancelled_future() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel();
+        let observed = Arc::new(AtomicBool::new(false));
+        let observed_for_future = observed.clone();
+        let future = async move {
+            cancel.cancelled().await;
+            observed_for_future.store(true, Ordering::SeqCst);
+            Err::<(), ToolError>(ToolError::Cancelled("cancelled".to_string()))
+        };
+        tokio::pin!(future);
+
+        IdaMcpServer::finish_cancelled_foreground("test_tool", future.as_mut()).await;
+
+        assert!(observed.load(Ordering::SeqCst));
     }
 
     #[test]
@@ -4956,7 +5024,11 @@ mod tests {
         grant: Option<Result<CloseTokenGrant, String>>,
     ) -> serde_json::Map<String, Value> {
         let mut map = serde_json::Map::new();
-        apply_close_metadata(&mut map, grant, close_hint_for(crate::ServerMode::Http));
+        apply_close_metadata(
+            &mut map,
+            grant,
+            close_hint_for(crate::ServerMode::Http, false),
+        );
         map
     }
 

--- a/src/server/tool_filter.rs
+++ b/src/server/tool_filter.rs
@@ -152,7 +152,8 @@ fn clean(input: &[String]) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::server::tool_filter::{ToolFilter, ToolFilterError, READ_ONLY_DENY_LIST};
+    use crate::tool_registry;
 
     fn cat(s: &str) -> Vec<String> {
         vec![s.to_string()]

--- a/src/tool_registry.rs
+++ b/src/tool_registry.rs
@@ -1004,7 +1004,7 @@ pub fn search_tools(query: &str, limit: usize) -> Vec<(&'static ToolInfo, Vec<&'
     }
 
     // Sort by score descending
-    results.sort_by(|a, b| b.2.cmp(&a.2));
+    results.sort_by_key(|(_, _, score)| std::cmp::Reverse(*score));
 
     // Return top results
     results

--- a/test/http_bootstrap.sh
+++ b/test/http_bootstrap.sh
@@ -89,15 +89,6 @@ echo "$open_resp" | grep -q "function_count" || {
   exit 1
 }
 
-if [[ ! -f "$BOOTSTRAP_I64" ]]; then
-  echo "bootstrap did not create $BOOTSTRAP_I64" >&2
-  if [[ -s "$server_log" ]]; then
-    echo "server output:" >&2
-    cat "$server_log" >&2
-  fi
-  exit 1
-fi
-
 close_token="$(echo "$open_resp" | sed -n 's/.*\\\"close_token\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p')"
 if [[ -n "$close_token" ]]; then
   close_args="{\"close_token\":\"$close_token\"}"
@@ -112,5 +103,14 @@ curl -sS \
   -H "Mcp-Session-Id: $session_id" \
   -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"close_idb\",\"arguments\":$close_args}}" \
   "http://127.0.0.1:$PORT/" >/dev/null
+
+if [[ ! -f "$BOOTSTRAP_I64" ]]; then
+  echo "bootstrap did not create $BOOTSTRAP_I64" >&2
+  if [[ -s "$server_log" ]]; then
+    echo "server output:" >&2
+    cat "$server_log" >&2
+  fi
+  exit 1
+fi
 
 echo "HTTP bootstrap test passed"

--- a/test/http_pool.sh
+++ b/test/http_pool.sh
@@ -275,7 +275,7 @@ second-open-failure)
 
   meta_resp="$(tool_call "$session_a" 30 idb_meta '{}' 10)"
   assert_tool_ok "$meta_resp" "idb_meta after failed second open"
-  printf '%s' "$meta_resp" | tool_text | jq -e '.path | contains("mini-a")' >/dev/null || {
+  printf '%s' "$meta_resp" | tool_text | jq -e '(.path // .input_file_path // "") | contains("mini-a")' >/dev/null || {
     echo "failed second open did not preserve the original database" >&2
     printf '%s\n' "$meta_resp" | jq . >&2
     cat "$server_log" >&2 || true

--- a/test/http_pool.sh
+++ b/test/http_pool.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# Exercise the HTTP worker-pool path. Cases:
+#   concurrency  - a long call in session A must not block session B
+#   exhaustion   - a third open fails when two workers are leased
+#   crash        - a child exit is contained and the session can re-open
+#   disconnect   - dropped client SSE streams release leased workers
+#   manager-disconnect - dropped standalone SSE closes pooled rmcp session without opening IDA
+#   second-open-failure - failed second open keeps the existing session lease/IDB
+set -euo pipefail
+
+CASE="${POOL_TEST_CASE:-${1:-concurrency}}"
+PORT="${PORT:-8765}"
+BIN="${MCP_HTTP_BIN:-./target/release/ida-mcp}"
+ORIGIN="${MCP_HTTP_ORIGIN:-http://localhost}"
+ALLOW_ORIGIN="${MCP_HTTP_ALLOW_ORIGIN:-http://localhost,http://127.0.0.1}"
+BIND_HOST="${MCP_HTTP_BIND_HOST:-127.0.0.1}"
+CONNECT_HOST="${MCP_HTTP_CONNECT_HOST:-127.0.0.1}"
+IDB_PATH="${IDB_PATH:-fixtures/mini}"
+MAX_WORKERS="${MAX_WORKERS:-2}"
+OP_TIMEOUT="${WORKER_OP_TIMEOUT:-20}"
+DISCONNECT_GRACE="${WORKER_DISCONNECT_GRACE:-1}"
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -x "$BIN" ]]; then
+  echo "missing server binary: $BIN" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+server_log="$tmpdir/server.log"
+headers_file="$tmpdir/headers.log"
+body_file="$tmpdir/body.log"
+
+cleanup() {
+  if [[ -n "${slow_pid:-}" ]]; then
+    kill "$slow_pid" >/dev/null 2>&1 || true
+    wait "$slow_pid" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${sse_a_pid:-}" ]]; then
+    kill "$sse_a_pid" >/dev/null 2>&1 || true
+    wait "$sse_a_pid" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${sse_b_pid:-}" ]]; then
+    kill "$sse_b_pid" >/dev/null 2>&1 || true
+    wait "$sse_b_pid" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+case "$IDB_PATH" in
+*.i64) fixture_ext=".i64" ;;
+*.idb) fixture_ext=".idb" ;;
+*) fixture_ext="" ;;
+esac
+
+fixture_a="$tmpdir/mini-a${fixture_ext}"
+fixture_b="$tmpdir/mini-b${fixture_ext}"
+fixture_c="$tmpdir/mini-c${fixture_ext}"
+if [[ "$CASE" != "manager-disconnect" ]]; then
+  cp "$IDB_PATH" "$fixture_a"
+  cp "$IDB_PATH" "$fixture_b"
+  cp "$IDB_PATH" "$fixture_c"
+fi
+
+curl_headers=(
+  -H "Content-Type: application/json"
+  -H "Accept: application/json, text/event-stream"
+  -H "Origin: $ORIGIN"
+)
+url="http://$CONNECT_HOST:$PORT/"
+
+"$BIN" serve-http \
+  --bind "$BIND_HOST:$PORT" \
+  --allow-origin "$ALLOW_ORIGIN" \
+  --max-workers "$MAX_WORKERS" \
+  --worker-idle-timeout-secs 60 \
+  --worker-op-timeout-secs "$OP_TIMEOUT" \
+  --worker-disconnect-grace-secs "$DISCONNECT_GRACE" \
+  >"$server_log" 2>&1 &
+server_pid=$!
+
+extract_json() {
+  awk '/^\{/{print; exit} /^data: \{/{sub(/^data: /,""); print; exit}'
+}
+
+init_session() {
+  local payload
+  payload="$(jq -cn '{jsonrpc:"2.0",id:1,method:"initialize",params:{protocolVersion:"2024-11-05",clientInfo:{name:"pool-test",version:"0.1"},capabilities:{}}}')"
+  for _ in {1..300}; do
+    if curl -sS -D "$headers_file" -o "$body_file" \
+      "${curl_headers[@]}" \
+      -d "$payload" \
+      "$url" >/dev/null 2>&1; then
+      local sid
+      sid="$(awk -F': ' 'tolower($1)=="mcp-session-id" {print $2}' "$headers_file" | tr -d '\r')"
+      if [[ -n "$sid" ]]; then
+        curl -sS "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+          -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+          "$url" >/dev/null
+        printf '%s' "$sid"
+        return 0
+      fi
+    fi
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  echo "failed to obtain Mcp-Session-Id" >&2
+  cat "$server_log" >&2 || true
+  exit 1
+}
+
+call_rpc() {
+  local sid="$1" rid="$2" method="$3" params="$4" max_time="${5:-0}"
+  local payload
+  payload="$(jq -cn --argjson id "$rid" --arg method "$method" --argjson params "$params" \
+    '{jsonrpc:"2.0",id:$id,method:$method,params:$params}')"
+  local curl_args=(-sS)
+  if [[ "$max_time" != "0" ]]; then
+    curl_args+=(--max-time "$max_time")
+  fi
+  curl "${curl_args[@]}" "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+    -d "$payload" \
+    "$url" | extract_json
+}
+
+tool_call() {
+  local sid="$1" rid="$2" tool="$3" args="$4" max_time="${5:-0}"
+  local params
+  params="$(jq -cn --arg name "$tool" --argjson arguments "$args" \
+    '{name:$name,arguments:$arguments}')"
+  call_rpc "$sid" "$rid" "tools/call" "$params" "$max_time"
+}
+
+tool_text() {
+  jq -r '.result.content[0].text // empty'
+}
+
+assert_tool_ok() {
+  local resp="$1" context="$2"
+  local is_error
+  is_error="$(printf '%s' "$resp" | jq -r '.result.isError // false')"
+  if [[ "$is_error" == "true" || -z "$resp" ]]; then
+    echo "$context failed" >&2
+    printf '%s\n' "$resp" | jq . >&2 || printf '%s\n' "$resp" >&2
+    cat "$server_log" >&2 || true
+    exit 1
+  fi
+}
+
+assert_tool_error_contains() {
+  local resp="$1" needle="$2" context="$3"
+  local is_error text
+  is_error="$(printf '%s' "$resp" | jq -r '.result.isError // false')"
+  text="$(printf '%s' "$resp" | tool_text)"
+  if [[ "$is_error" != "true" || "$text" != *"$needle"* ]]; then
+    echo "$context did not return expected error containing '$needle'" >&2
+    printf '%s\n' "$resp" | jq . >&2 || printf '%s\n' "$resp" >&2
+    cat "$server_log" >&2 || true
+    exit 1
+  fi
+}
+
+wait_for_log() {
+  local needle="$1" timeout_secs="$2"
+  local deadline=$((SECONDS + timeout_secs))
+  while ((SECONDS <= deadline)); do
+    if grep -Fq "$needle" "$server_log"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+open_fixture() {
+  local sid="$1" rid="$2" path="$3"
+  local args resp
+  args="$(jq -cn --arg path "$path" '{path:$path}')"
+  resp="$(tool_call "$sid" "$rid" open_idb "$args" 45)"
+  assert_tool_ok "$resp" "open_idb $path"
+  printf '%s' "$resp" | tool_text | jq -e '.function_count' >/dev/null || {
+    echo "open_idb response missing function_count for $path" >&2
+    printf '%s\n' "$resp" | jq . >&2
+    exit 1
+  }
+}
+
+close_session() {
+  local sid="$1" rid="$2"
+  tool_call "$sid" "$rid" close_idb '{}' 10 >/dev/null || true
+}
+
+start_standalone_stream() {
+  local sid="$1" name="$2"
+  curl -sS -N "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+    "$url" >"$tmpdir/$name-sse.log" 2>&1 &
+  local pid=$!
+  sleep 0.5
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "standalone SSE stream for $name exited unexpectedly" >&2
+    cat "$tmpdir/$name-sse.log" >&2 || true
+    cat "$server_log" >&2 || true
+    exit 1
+  fi
+  printf '%s' "$pid"
+}
+
+session_a="$(init_session)"
+session_b="$(init_session)"
+session_c="$(init_session)"
+
+case "$CASE" in
+concurrency)
+  open_fixture "$session_a" 10 "$fixture_a"
+  open_fixture "$session_b" 20 "$fixture_b"
+
+  slow_args="$(jq -cn --arg code 'import time; time.sleep(8); print("slow done")' \
+    '{code:$code,timeout_secs:15}')"
+  slow_resp_file="$tmpdir/slow-response.json"
+  tool_call "$session_a" 30 run_script "$slow_args" 20 >"$slow_resp_file" &
+  slow_pid=$!
+  sleep 1
+
+  status_resp="$(tool_call "$session_b" 31 analysis_status '{}' 4)"
+  assert_tool_ok "$status_resp" "analysis_status while session A is busy"
+  if ! kill -0 "$slow_pid" 2>/dev/null; then
+    echo "slow run_script finished before concurrency check completed" >&2
+    cat "$slow_resp_file" >&2 || true
+    exit 1
+  fi
+
+  wait "$slow_pid"
+  unset slow_pid
+  slow_resp="$(cat "$slow_resp_file")"
+  assert_tool_ok "$slow_resp" "slow run_script"
+  printf '%s' "$slow_resp" | tool_text | grep -q 'slow done' || {
+    echo "slow run_script output missing marker" >&2
+    printf '%s\n' "$slow_resp" | jq . >&2
+    exit 1
+  }
+  close_session "$session_a" 90
+  close_session "$session_b" 91
+  echo "HTTP pool concurrency test passed"
+  ;;
+
+exhaustion)
+  open_fixture "$session_a" 10 "$fixture_a"
+  open_fixture "$session_b" 20 "$fixture_b"
+  third_args="$(jq -cn --arg path "$fixture_c" '{path:$path}')"
+  third_resp="$(tool_call "$session_c" 30 open_idb "$third_args" 15)"
+  assert_tool_error_contains "$third_resp" "Worker pool exhausted" "third pooled open"
+  close_session "$session_a" 90
+  close_session "$session_b" 91
+  echo "HTTP pool exhaustion test passed"
+  ;;
+
+second-open-failure)
+  open_fixture "$session_a" 10 "$fixture_a"
+  second_args="$(jq -cn --arg path "$fixture_b" '{path:$path}')"
+  second_resp="$(tool_call "$session_a" 20 open_idb "$second_args" 15)"
+  assert_tool_error_contains "$second_resp" "A database is already open" "second pooled open"
+
+  meta_resp="$(tool_call "$session_a" 30 idb_meta '{}' 10)"
+  assert_tool_ok "$meta_resp" "idb_meta after failed second open"
+  printf '%s' "$meta_resp" | tool_text | jq -e '.path | contains("mini-a")' >/dev/null || {
+    echo "failed second open did not preserve the original database" >&2
+    printf '%s\n' "$meta_resp" | jq . >&2
+    cat "$server_log" >&2 || true
+    exit 1
+  }
+
+  close_session "$session_a" 90
+  echo "HTTP pool second-open failure test passed"
+  ;;
+
+crash)
+  open_fixture "$session_a" 10 "$fixture_a"
+  open_fixture "$session_b" 20 "$fixture_b"
+  crash_args="$(jq -cn --arg code 'import os; os._exit(139)' '{code:$code,timeout_secs:10}')"
+  crash_resp="$(tool_call "$session_a" 30 run_script "$crash_args" 15)"
+  assert_tool_error_contains "$crash_resp" "Worker" "crashing child call"
+
+  status_resp="$(tool_call "$session_b" 31 analysis_status '{}' 10)"
+  assert_tool_ok "$status_resp" "analysis_status in unaffected session"
+
+  open_fixture "$session_a" 40 "$fixture_c"
+  close_session "$session_a" 90
+  close_session "$session_b" 91
+  echo "HTTP pool crash-containment test passed"
+  ;;
+
+disconnect)
+  open_fixture "$session_a" 10 "$fixture_a"
+  open_fixture "$session_b" 20 "$fixture_b"
+
+  sse_a_pid="$(start_standalone_stream "$session_a" session-a)"
+  sse_b_pid="$(start_standalone_stream "$session_b" session-b)"
+  kill "$sse_a_pid" "$sse_b_pid" >/dev/null 2>&1 || true
+  wait "$sse_a_pid" "$sse_b_pid" >/dev/null 2>&1 || true
+  sleep "$((DISCONNECT_GRACE + 2))"
+
+  open_fixture "$session_c" 30 "$fixture_c"
+  close_session "$session_c" 91
+  echo "HTTP pool disconnect cleanup test passed"
+  ;;
+
+manager-disconnect)
+  sse_a_pid="$(start_standalone_stream "$session_a" session-a)"
+  kill "$sse_a_pid" >/dev/null 2>&1 || true
+  wait "$sse_a_pid" >/dev/null 2>&1 || true
+  unset sse_a_pid
+
+  if ! wait_for_log "Using disconnect-aware pooled HTTP session manager" 5; then
+    echo "pooled HTTP path did not install the disconnect-aware session manager" >&2
+    cat "$server_log" >&2 || true
+    exit 1
+  fi
+  if ! wait_for_log "closing pooled HTTP session after client stream disconnect" "$((DISCONNECT_GRACE + 5))"; then
+    echo "pooled session manager did not close abandoned standalone SSE stream" >&2
+    cat "$server_log" >&2 || true
+    exit 1
+  fi
+  echo "HTTP pool manager disconnect wiring test passed"
+  ;;
+
+*)
+  echo "unknown POOL_TEST_CASE: $CASE" >&2
+  exit 2
+  ;;
+esac

--- a/test/justfile
+++ b/test/justfile
@@ -94,6 +94,38 @@ test: fixture
     rm -f "$tmp"
     echo "✅ Stdio test passed"
 
+# Verify the license-expiry preflight runs and reports a healthy license
+test-license: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        exit 1
+    fi
+    echo "🧪 Running license preflight test..."
+    log="$(mktemp)"
+    printf '%s\n' \
+      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"lic","version":"0"},"capabilities":{}}}' \
+      '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+      '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"open_idb","arguments":{"path":"{{ test_bin }}"}}}' \
+      '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"close_idb","arguments":{}}}' \
+      | RUST_LOG="{{ rust_log }}" "{{ server_bin }}" serve >/dev/null 2>"$log" || true
+    if rg -q 'IDA license expired|IDA license is invalid' "$log"; then
+        echo "❌ License preflight reports an unhealthy license:" >&2
+        rg 'IDA license' "$log" >&2
+        rm -f "$log"
+        exit 1
+    fi
+    if ! rg -q 'IDA license valid' "$log" && ! rg -q 'IDA license expires in' "$log"; then
+        echo "❌ License preflight did not run (no expiry log line). Init log tail:" >&2
+        rg 'Initializing|runtime version|license' "$log" >&2 || tail -20 "$log" >&2
+        rm -f "$log"
+        exit 1
+    fi
+    rg 'IDA license' "$log"
+    rm -f "$log"
+    echo "✅ License preflight test passed"
+
 # Run HTTP integration test
 test-http: fixture
     #!/usr/bin/env bash

--- a/test/justfile
+++ b/test/justfile
@@ -15,7 +15,7 @@ default:
 
 # Build test fixture
 fixture:
-    {{ cc }} {{ cflags }} -o "{{ test_bin }}" "{{ test_src }}"
+    @[ "{{ test_bin }}" -nt "{{ test_src }}" ] || {{ cc }} {{ cflags }} -o "{{ test_bin }}" "{{ test_src }}"
 
 # Bootstrap a deterministic .i64 fixture for tests that should not wait on raw-binary auto-analysis
 test-bootstrap: fixture
@@ -26,20 +26,22 @@ test-bootstrap: fixture
         echo "Run 'cargo build --release' first"
         exit 1
     fi
-    if [ -f "{{ test_i64 }}" ]; then
-        echo "✅ Bootstrap fixture already present: {{ test_i64 }}"
-        exit 0
-    fi
     LOCK="{{ test_lock }}"
     if [ -f "$LOCK" ]; then
         pid=$(awk -F= '$1=="pid"{print $2}' "$LOCK" | tr -d '\r')
         if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
             echo "Lock file $LOCK is held by pid $pid; close that server first." >&2
             exit 1
-        else
-            rm -f "$LOCK"
         fi
+        echo "🧹 Removing stale lock $LOCK (pid $pid dead)"
+        rm -f "$LOCK"
     fi
+    rm -f "{{ test_bin }}".id0 "{{ test_bin }}".id1 "{{ test_bin }}".id2 "{{ test_bin }}".nam "{{ test_bin }}".til
+    if [ -f "{{ test_i64 }}" ] && [ "{{ test_i64 }}" -nt "{{ test_bin }}" ]; then
+        echo "✅ Bootstrap fixture already present: {{ test_i64 }}"
+        exit 0
+    fi
+    rm -f "{{ test_i64 }}"
     echo "🧪 Bootstrapping {{ test_i64 }} via MCP server..."
     RUST_LOG="{{ rust_log }}" MCP_HTTP_BIN="{{ server_bin }}" IDB_PATH="{{ test_bin }}" bash ./http_bootstrap.sh
     echo "✅ Bootstrap fixture created: {{ test_i64 }}"
@@ -165,6 +167,135 @@ test-http-recovery: fixture
         MCP_HTTP_BIN="{{ server_bin }}" \
         ./http_close_recovery.sh
     echo "✅ HTTP close-recovery test passed"
+
+# Pool tests use raw fixture copies in tmpdirs instead of the shared mini.i64
+# so killed workers cannot poison later runs with stale packed fixture state.
+
+# Run HTTP worker-pool concurrency test
+test-pool: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for pool test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP worker-pool concurrency test..."
+    PORT=$((9300 + RANDOM % 500)) \
+        POOL_TEST_CASE=concurrency \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_pool.sh
+    echo "✅ HTTP worker-pool concurrency test passed"
+
+# Run HTTP worker-pool crash-containment test
+test-pool-crash: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for pool crash test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP worker-pool crash-containment test..."
+    PORT=$((9400 + RANDOM % 500)) \
+        POOL_TEST_CASE=crash \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_pool.sh
+    echo "✅ HTTP worker-pool crash-containment test passed"
+
+# Run HTTP worker-pool exhaustion test
+test-pool-exhaustion: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for pool exhaustion test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP worker-pool exhaustion test..."
+    PORT=$((9500 + RANDOM % 500)) \
+        POOL_TEST_CASE=exhaustion \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_pool.sh
+    echo "✅ HTTP worker-pool exhaustion test passed"
+
+# Run HTTP worker-pool failed-second-open lease preservation test
+test-pool-second-open: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for pool second-open test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP worker-pool second-open failure test..."
+    PORT=$((9550 + RANDOM % 500)) \
+        POOL_TEST_CASE=second-open-failure \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_pool.sh
+    echo "✅ HTTP worker-pool second-open failure test passed"
+
+# Run HTTP worker-pool abandoned-client cleanup test
+test-pool-disconnect: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for pool disconnect test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP worker-pool abandoned-client cleanup test..."
+    PORT=$((9600 + RANDOM % 500)) \
+        POOL_TEST_CASE=disconnect \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_pool.sh
+    echo "✅ HTTP worker-pool abandoned-client cleanup test passed"
+
+# Run HTTP worker-pool session-manager disconnect wiring test without opening IDA
+test-pool-manager-disconnect:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for pool manager-disconnect test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP worker-pool session-manager disconnect wiring test..."
+    PORT=$((9700 + RANDOM % 500)) \
+        POOL_TEST_CASE=manager-disconnect \
+        RUST_LOG="{{ rust_log }}" IDB_PATH="{{ test_bin }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_pool.sh
+    echo "✅ HTTP worker-pool session-manager disconnect wiring test passed"
 
 # Run IDAPython script integration test
 test-script: test-bootstrap


### PR DESCRIPTION
## Summary
- add pooled HTTP mode for `serve-http --max-workers N`, leasing one child `ida-mcp worker` per HTTP session
- preserve the legacy in-process HTTP path when `--max-workers 1`
- reclaim leases on `close_idb`, standalone SSE disconnect, idle timeout, shutdown, and failed/cancelled worker operations
- default pooled HTTP session keep-alive to 300s and document idle worker reuse so live child processes are not mistaken for leaked leases

Refs #26.

## Verification
- `just check`
- `just test-pool-manager-disconnect`

## Not run
- Linux/Windows VM smoke tests
- fixture-backed pool integrations in this final cleanup pass