### PR TITLE
Update Rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ida-mcp"
 version = "9.3.24"
-edition = "2021"
+edition = "2024"
 description = "Headless IDA Pro MCP Server"
 license = "MIT"
 repository = "https://github.com/blacktop/ida-mcp-rs"

--- a/src/crash_guard.rs
+++ b/src/crash_guard.rs
@@ -13,8 +13,8 @@
 use crate::error::ToolError;
 
 #[cfg(unix)]
-extern "C" {
-    fn crash_guard_call(
+unsafe extern "C" {
+    unsafe fn crash_guard_call(
         func: extern "C" fn(*mut std::ffi::c_void),
         ctx: *mut std::ffi::c_void,
     ) -> std::ffi::c_int;


### PR DESCRIPTION
Please run `cargo clippy --fix` and `cargo fmt` after merging this