### PR TITLE
chore: release 9.3.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ida-mcp"
-version = "9.3.24"
+version = "9.3.25"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ida-mcp"
-version = "9.3.24"
+version = "9.3.25"
 edition = "2021"
 description = "Headless IDA Pro MCP Server"
 license = "MIT"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ida-mcp
-version: '9.3.24'
+version: '9.3.25'
 summary: Headless IDA Pro MCP Server for AI-powered binary analysis
 description: |
   ida-mcp exposes IDA Pro's analysis engine over the Model Context Protocol,


### PR DESCRIPTION
Release metadata bump for v9.3.25. The v9.3.25 tag and release assets are already published; this keeps main aligned with the stable release.