### PR TITLE
chore: update rmcp to 2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,9 +1512,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,9 +1512,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools", "command-line-utilities"]
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 idalib = { git = "https://github.com/blacktop/idalib.git", branch = "sdk-9.3.1" }
-rmcp = { version = "1.7", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "schemars"] }
+rmcp = { version = "2.1.0", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "schemars"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "signal", "process", "io-util"] }
 tokio-util = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools", "command-line-utilities"]
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 idalib = { git = "https://github.com/blacktop/idalib.git", branch = "sdk-9.3.1" }
-rmcp = { version = "2.1.0", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "schemars"] }
+rmcp = { version = "2.2.0", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "schemars"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "signal", "process", "io-util"] }
 tokio-util = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 //! Tool execution errors are returned with `is_error: true` in CallToolResult,
 //! while protocol errors (invalid tool name, malformed args) are handled by rmcp.
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock as Content};
 use thiserror::Error;
 
 /// Tool execution errors - returned with is_error: true in CallToolResult

--- a/src/ida/pool.rs
+++ b/src/ida/pool.rs
@@ -8,8 +8,8 @@ use crate::ida::types::*;
 use crate::ida::worker::MAX_TIMEOUT_SECS;
 use futures_util::future::join_all;
 use rmcp::handler::client::ClientHandler;
-use rmcp::model::{CallToolResult, ClientInfo, JsonObject, LoggingMessageNotificationParam};
-use rmcp::service::{NotificationContext, Peer, RoleClient, RunningService};
+use rmcp::model::{CallToolResult, ClientInfo, JsonObject};
+use rmcp::service::{Peer, RoleClient, RunningService};
 use rmcp::transport::child_process::TokioChildProcess;
 use rmcp::ServiceExt;
 use serde::de::DeserializeOwned;
@@ -93,26 +93,9 @@ pub struct PooledWorkerHandle {
 }
 
 #[derive(Clone)]
-struct ParentClientHandler {
-    worker_id: usize,
-}
+struct ParentClientHandler;
 
 impl ClientHandler for ParentClientHandler {
-    async fn on_logging_message(
-        &self,
-        params: LoggingMessageNotificationParam,
-        _context: NotificationContext<RoleClient>,
-    ) {
-        debug!(
-            target: "ida_mcp::worker",
-            worker_id = self.worker_id,
-            level = ?params.level,
-            logger = ?params.logger,
-            data = ?params.data,
-            "child worker log"
-        );
-    }
-
     fn get_info(&self) -> ClientInfo {
         ClientInfo::default()
     }
@@ -443,7 +426,7 @@ impl WorkerPool {
             })?;
         let pid = transport.id();
         let stderr_task = spawn_stderr_relay(id, stderr);
-        let handler = ParentClientHandler { worker_id: id };
+        let handler = ParentClientHandler;
         let service = handler.serve(transport).await.map_err(|err| {
             ToolError::RemoteProtocol(format!("failed to initialize worker {id}: {err}"))
         })?;

--- a/src/ida/remote.rs
+++ b/src/ida/remote.rs
@@ -154,7 +154,7 @@ pub(crate) async fn call_tool(
 mod tests {
     use crate::error::ToolError;
     use crate::ida::remote::{parse_json, parse_value};
-    use rmcp::model::{CallToolResult, Content};
+    use rmcp::model::{CallToolResult, ContentBlock as Content};
     use serde_json::{json, Value};
 
     #[test]

--- a/src/server/http_config.rs
+++ b/src/server/http_config.rs
@@ -32,6 +32,7 @@ fn session_manager_with_keep_alive(session_keep_alive_secs: u64) -> LocalSession
     } else {
         Some(Duration::from_secs(session_keep_alive_secs))
     };
+    manager.session_config.sse_retry = None;
     manager
 }
 
@@ -415,6 +416,15 @@ mod tests {
             manager.session_config.keep_alive,
             Some(Duration::from_secs(1800)),
             "explicit value must override rmcp's 300s default that killed long IDA calls"
+        );
+    }
+
+    #[test]
+    fn session_manager_disables_request_wise_priming() {
+        let manager = build_session_manager(1800);
+        assert!(
+            manager.session_config.sse_retry.is_none(),
+            "request-wise SSE priming must match the outer streamable config"
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,7 +21,10 @@ use crate::server::operation::{
 use crate::tool_registry::{self, ToolCategory};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
-    model::{CallToolResult, Content, ServerCapabilities, ServerInfo, Tool, ToolAnnotations},
+    model::{
+        CallToolResult, ContentBlock as Content, ServerCapabilities, ServerInfo, Tool,
+        ToolAnnotations,
+    },
     schemars::{schema_for, JsonSchema},
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
@@ -4472,7 +4475,7 @@ impl ServerHandler for IdaMcpServer {
 
     async fn get_task_info(
         &self,
-        request: GetTaskInfoParams,
+        request: GetTaskParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<GetTaskResult, McpError> {
         let state = self.task_registry.get(&request.task_id).ok_or_else(|| {
@@ -4481,15 +4484,12 @@ impl ServerHandler for IdaMcpServer {
                 Some(json!({ "task_id": request.task_id })),
             )
         })?;
-        Ok(GetTaskResult {
-            meta: None,
-            task: task_state_to_mcp(&state),
-        })
+        Ok(GetTaskResult::new(task_state_to_mcp(&state)))
     }
 
     async fn get_task_result(
         &self,
-        request: GetTaskResultParams,
+        request: GetTaskPayloadParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<GetTaskPayloadResult, McpError> {
         let state = self.task_registry.get(&request.task_id);
@@ -4526,10 +4526,7 @@ impl ServerHandler for IdaMcpServer {
                     None,
                 )
             })?;
-            Ok(CancelTaskResult {
-                meta: None,
-                task: task_state_to_mcp(&state),
-            })
+            Ok(CancelTaskResult::new(task_state_to_mcp(&state)))
         } else {
             Err(McpError::invalid_params(
                 "Task not found or not running",
@@ -4841,7 +4838,7 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
 
     async fn get_task_info(
         &self,
-        request: GetTaskInfoParams,
+        request: GetTaskParams,
         ctx: RequestContext<RoleServer>,
     ) -> Result<GetTaskResult, McpError> {
         self.inner.get_task_info(request, ctx).await
@@ -4849,7 +4846,7 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
 
     async fn get_task_result(
         &self,
-        request: GetTaskResultParams,
+        request: GetTaskPayloadParams,
         ctx: RequestContext<RoleServer>,
     ) -> Result<GetTaskPayloadResult, McpError> {
         self.inner.get_task_result(request, ctx).await
@@ -5274,7 +5271,7 @@ mod tests {
 
     #[test]
     fn task_payload_preserves_valid_call_tool_result() {
-        let result = CallToolResult::success(vec![rmcp::model::Content::text("ok")]);
+        let result = CallToolResult::success(vec![rmcp::model::ContentBlock::text("ok")]);
         let as_value = serde_json::to_value(&result).expect("serialize CallToolResult");
         assert_eq!(task_payload_result_value(Some(as_value.clone())), as_value);
     }


### PR DESCRIPTION
Updates rmcp/rmcp-macros from 1.7.0 to 2.2.0 and adapts the server to the 2.x model/task API changes. The final bump from 2.1.0 to 2.2.0 is dependency-only and picks up upstream conformance/cancellation/streamable-HTTP fixes.

Changes:
- Use rmcp 2.x ContentBlock model for tool result content.
- Move task handlers off deprecated GetTaskInfo/GetTaskResult aliases and use the new task result constructors.
- Drop the deprecated client logging notification override; worker stderr relay remains.
- Disable LocalSessionManager request-wise SSE retry priming to match the outer streamable HTTP config.
- Bump rmcp/rmcp-macros from 2.1.0 to 2.2.0 without unrelated transitive lockfile churn.

Local macOS verification:
- just check passed: fmt, clippy -D warnings, 134 lib tests, 2 bin tests, doctests.
- just test-bootstrap passed and regenerated test/fixtures/mini.i64.
- just test passed.
- just test-http passed.
- just test-http-recovery passed.
- just test-pool passed.
- just test-pool-crash passed.
- just test-pool-exhaustion passed.
- just test-pool-second-open passed.
- just test-pool-disconnect passed.
- just test-pool-manager-disconnect passed.
- just test-script passed.
- just test-observability passed.
- just test-elicitation passed.
- just test-rebuild-idb passed.
- just test-license passed.
- just test-crash-guard passed.
- just test-callees-indirect passed.
- just test-tool-filter passed.
- just test-dsc passed after wiring the default /tmp/ios_sys_mount DSC path to a real iOS DSC; the dsc_add_dylib warning is non-fatal and the recipe completed successfully.

VM verification:
- Linux aarch64 VM: PR head 0055b90 built in release against IDA 9.3 and ida-mcp --version returned 9.3.25. Full just check hit VM disk pressure during test-link after fmt/clippy had completed.
- Windows VM: PR head 0055b90 built release x86_64-pc-windows-msvc, copied beside IDA 9.3 for DLL discovery, and ida-mcp.exe --version returned 9.3.25.

CI:
- GitHub Actions run 28971232155 passed on Linux x86_64, Linux arm64, macOS arm64, macOS x86_64, and Windows x86_64. Release job skipped as expected for PRs.