### PR TITLE
feat(mcp): add MCP 2026-07-28 sessionless lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,15 +275,24 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -403,6 +412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +453,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -511,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -521,26 +560,38 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
@@ -773,6 +824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +882,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1513,15 +1582,16 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "futures",
+ "hmac",
  "http",
  "http-body",
  "http-body-util",
@@ -1533,6 +1603,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "sse-stream",
  "thiserror 2.0.18",
  "tokio",
@@ -1546,15 +1617,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1675,6 +1746,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1762,6 +1844,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2004,6 +2097,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools", "command-line-utilities"]
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 idalib = { git = "https://github.com/blacktop/idalib.git", branch = "sdk-9.4.0" }
-rmcp = { version = "2.2.0", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "schemars"] }
+rmcp = { version = "3.1.2", features = ["server", "client", "transport-io", "transport-child-process", "transport-streamable-http-server", "elicitation", "request-state", "schemars"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "signal", "process", "io-util"] }
 tokio-util = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ strings(limit: 10)
 
 # For xrefs/decompile on large binaries, run analysis in background
 analyze_funcs(background: true)   # returns task_id
-task_status(task_id: "analyze-1") # poll progress
+task_status(task_id: "analyze-<random>") # poll progress (ID from the analyze_funcs response)
 
 # Decompile (requires Hex-Rays + completed analysis)
 decompile(address: "0x100000f00")
@@ -210,6 +210,15 @@ immediately, but the child process may stay alive idle for reuse until
 retry later. Pooled mode requires stateful HTTP sessions; `--max-workers > 1`
 is rejected with `--stateless`.
 
+MCP `2026-07-28` uses the sessionless `server/discover` lifecycle. It is
+supported over stdio and the default single-worker HTTP mode, including
+multi-round elicitation and the `io.modelcontextprotocol/tasks` extension for
+background `open_dsc` calls. Pooled HTTP (`--max-workers > 1`) deliberately
+advertises protocol versions only through `2025-11-25`: its worker lease is
+session-affine, and MCP 2026 has no session identifier to preserve that routing
+across requests. MCP 2026 requests to pooled HTTP fail with an unsupported
+protocol-version error instead of risking dispatch to a different IDA worker.
+
 If an SSE-capable client exits without sending `close_idb` or HTTP `DELETE`,
 pooled mode closes the session after its standalone SSE stream disconnects and
 the `--worker-disconnect-grace-secs` reconnect grace elapses.
@@ -227,7 +236,7 @@ open_dsc(path: "/path/to/dyld_shared_cache_arm64e", arch: "arm64e",
          module: "/usr/lib/libobjc.A.dylib")
 
 # If a legacy background task was started, poll until done
-task_status(task_id: "dsc-1")
+task_status(task_id: "dsc-<random>")  # ID from the open_dsc response
 
 # Load additional frameworks for cross-module references
 open_dsc(path: "/path/to/dyld_shared_cache_arm64e", arch: "arm64e",

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,13 +5,16 @@
 ```bash
 just test         # Stdio JSONL integration test
 just test-http    # HTTP/SSE integration test
+just test-modern  # MCP 2026 discover/stateless lifecycle test
 just test-script  # IDAPython script execution test
 just test-elicitation # open_idb auto-background elicitation test
+just test-session-cancel # legacy-session cancel-on-disconnect test
+just test-http-startup # HTTP bind-failure exit status (no IDA license needed)
 just test-dsc /path/to/dyld_shared_cache_arm64e  # DSC loading test
 just cargo-test   # Unit tests (no IDA required)
 ```
 
-All integration tests require IDA Pro with a valid license. Run `cargo build` first.
+All integration tests require IDA Pro with a valid license. Run `just build` first.
 
 ## What's tested
 
@@ -29,6 +32,17 @@ All integration tests require IDA Pro with a valid license. Run `cargo build` fi
 - `tools/list` returns the full tool list
 - Database operations work over HTTP (`open_idb`, `list_functions`, `close_idb` with close_token)
 
+**MCP 2026 test** (`just test-modern`)
+- Exercises `server/discover`, `tools/list`, and `tools/call` over stdio
+- Rejects MCP 2026 requests with incomplete required request metadata
+- Exercises the same lifecycle over sessionless single-worker HTTP and verifies
+  that no legacy session ID is created
+- Verifies a legacy stdio task remains visible on the same connection when one
+  request carries full routing metadata and the next omits it
+- Verifies pooled HTTP advertises versions only through `2025-11-25`, rejects
+  a `2026-07-28` request, and rejects sessionless inline-metadata tool calls
+  that declare a legacy version
+
 **Script test** (`just test-script`)
 - Opens a binary, then runs inline Python via `run_script`
 - Verifies stdout/stderr capture
@@ -39,6 +53,26 @@ All integration tests require IDA Pro with a valid license. Run `cargo build` fi
 - Creates a sparse Mach-O fixture just over 50 MiB
 - Verifies `open_idb(auto_analyse=true)` silently routes analysis to a background task when the client has no elicitation capability
 - Verifies an elicitation-capable client receives `elicitation/create`, accepts it, and gets `analysis_background=true` plus a pollable `analysis_task_id`
+- Verifies MCP `2026-07-28` returns `input_required`, accepts the echoed
+  integrity-protected `requestState` plus `inputResponses`, and completes the
+  retried tool call
+
+**Startup-failure test** (`just test-http-startup`)
+- Squats a port with a pooled parent (binds in ms, takes no IDA license), then
+  starts each HTTP topology against it
+- Asserts single-worker HTTP exits nonzero, does not wedge (watchdog SIGKILL
+  would show as 137), and releases its IDA worker loop
+- Asserts pooled HTTP exits nonzero and never logs a clean stop it didn't achieve
+- Needs no IDA license, database, or fixture
+
+**Session-cancel test** (`just test-session-cancel`)
+- Single-worker HTTP: a legacy session starts a slow foreground `open_idb`
+  (observed via `recent_operations`), queues a background `analyze_funcs`
+  behind it, then DELETEs the session
+- Verifies a second legacy session cannot reuse the deduplicated task ID or
+  poll the first session's task
+- Verifies the server records owner cancellation only after the background
+  operation settles and never records successful completion for that task
 
 **DSC test** (`just test-dsc <path>`)
 - Requires a real `dyld_shared_cache_arm64e` file
@@ -48,7 +82,8 @@ All integration tests require IDA Pro with a valid license. Run `cargo build` fi
 
 **Unit tests** (`just cargo-test`)
 - `src/dsc.rs` — file type strings, idat args, script generation, Python string escaping
-- `src/server/task.rs` — task registry lifecycle, deduplication, cancellation, ISO timestamps
+- `src/server/task.rs` — task registry lifecycle, owner-scoped access and
+  deduplication, bounded admission, cancellation, and ISO timestamps
 
 ## Test fixture
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -8,7 +8,7 @@
 - `tools/list` returns the full tool set (currently 73 tools)
 - `tool_catalog(query=...)` searches all tools by intent
 - `tool_help(name=...)` returns full documentation and schema
-- Call `close_idb` when done to release locks; in multi-client servers coordinate before closing (HTTP/SSE requires close_token from open_idb)
+- Call `close_idb` when done to release locks; in multi-client servers coordinate before closing (HTTP/SSE requires the close_token from `open_idb` unless the request is in the owning legacy session)
 
 Note: `open_idb` accepts .i64/.idb or raw binaries (Mach-O/ELF/PE). Raw binaries are
 auto-analyzed and saved as a .i64 alongside the input. If that generated .i64

--- a/docs/TRANSPORTS.md
+++ b/docs/TRANSPORTS.md
@@ -18,7 +18,9 @@ process the response — which retires the `progressToken` — before the
 notification handlers run, dropping the transport with "unknown progress
 token". Phase progress is recorded server-side instead and surfaced via the
 `recent_operations` tool. Long-running work (e.g. `analyze_funcs`) should be
-launched through the task system (`enqueue_task` + poll `task_status`).
+launched with the tool's background option and polled through `task_status`.
+Clients declaring the MCP Tasks extension also receive native task handles for
+background `open_dsc` calls.
 
 ## Streamable HTTP (multi-client transport)
 
@@ -53,7 +55,17 @@ launched through the task system (`enqueue_task` + poll `task_status`).
 ```
 
 Options:
-- `--stateless`: POST-only mode (no sessions)
+- `--stateless`: force POST-only mode for legacy protocols. MCP `2026-07-28`
+  is always sessionless, with or without this flag.
+- `--json-response`: prefer `application/json` over SSE framing for
+  sessionless responses (`--stateless` mode and all MCP `2026-07-28`
+  requests)
+- `--max-request-body-mib`: maximum accepted request body (default 16, range
+  1-1024). Bulk `patch` sends binary as hex at ~2x the raw size and
+  `run_script` sends whole sources, so rmcp's 4 MiB default is too small; the
+  endpoint is unauthenticated and each in-flight request can retain up to this
+  much, so raise it deliberately. Over-cap requests get a transport-level HTTP
+  413 that names the limit, outside the JSON-RPC envelope.
 - `--allow-origin`: comma-separated `Origin` allowlist (default: `http://localhost,http://127.0.0.1`)
 - `--allow-host`: comma-separated extra `Host` allowlist for DNS names or
   alternate authorities; pass a quoted `*` or an empty value to disable the check
@@ -72,6 +84,45 @@ Options:
 - `--worker-disconnect-grace-secs`: reconnect grace before a pooled session is
   closed after the client drops its standalone SSE stream
 
+## Protocol lifecycle
+
+The server supports the legacy `initialize` lifecycle from `2024-11-05`
+through `2025-11-25`. MCP `2026-07-28` uses `server/discover` and per-request
+metadata instead; it is supported on stdio and single-worker HTTP. Single-worker
+HTTP shares task, operation, and MRTR state across the fresh handler instances
+created for sessionless requests. Background tasks (DSC loading, auto-analysis)
+spawned by a legacy session are cancelled when that session closes; tasks
+spawned by sessionless MCP 2026 requests outlive their request and run until
+completion, `tasks/cancel`, or server shutdown. Legacy task IDs are scoped to
+their owning session for deduplication, polling, updates, and cancellation; a
+different legacy session receives the same response as it would for an unknown
+ID. Stdio task ownership remains connection-scoped even if request metadata is
+present on only some messages. Sessionless HTTP requests share the runtime task
+owner because MCP 2026 provides no stable session identity across requests.
+Under `--stateless`, every HTTP request is served by a per-request handler
+regardless of protocol version, so legacy requests there also use the shared
+runtime owner and lifetime — their background tasks survive the request and
+stay pollable across requests. Within that shared owner, the task ID is the
+only access credential: IDs carry full per-task randomness and should be
+treated like a `close_token`, not logged or shared.
+
+Task cancellation is cooperative. A cancellation request signals the active
+operation, but the task remains `working` while an uncancellable synchronous
+IDA call settles. Only then does the server publish the terminal `cancelled`
+state, so a terminal task never has IDA work still running behind it. The
+legacy idat subprocess is the exception: cancellation kills it, reaps it, and
+removes its partial database output before publishing `cancelled`, so a later
+`open_dsc` cannot reuse a half-written database.
+
+Pooled HTTP (`--max-workers > 1`) is intentionally limited to protocol versions
+through `2025-11-25`. Its IDA worker lease is bound to a legacy HTTP session,
+while MCP 2026 removes sessions. The server advertises that boundary through
+`server/discover` and rejects MCP 2026 requests rather than losing worker
+affinity between calls. Tool calls that carry the full sessionless request
+metadata with a legacy protocol version are rejected for the same reason: the
+transport routes them without a session, which would lease a fresh IDA worker
+per request.
+
 ## Concurrency model
 
 IDA requires main-thread access, and one IDA process can own only one active
@@ -86,6 +137,41 @@ pooled mode closes the abandoned session when its standalone SSE stream
 disconnects and the reconnect grace elapses. POST-only clients have no
 persistent stream to observe, so their orphaned sessions are reclaimed by
 `--session-keep-alive-secs`.
+
+## Logging and sensitive payloads
+
+Tool spans record only sanitized fields (paths, sizes, booleans) — never
+ownership tokens, MRTR state, elicitation answers, script sources, patch
+bytes, or comment/rename text.
+
+Scope the filter when troubleshooting: `RUST_LOG=ida_mcp=debug`. A bare
+`RUST_LOG=debug` also enables the MCP SDK's own request logging, which writes
+whole JSON-RPC envelopes — including tool arguments — to stderr.
+
+## Known limitations
+
+- **Sessionless `close_token` recovery.** Under MCP 2026 every HTTP request is
+  a fresh ownership context, so re-opening an already-open database does not
+  re-issue its `close_token`. A client that lost the token from the original
+  `open_idb` response must use `close_idb` with `force=true` to release the
+  database.
+- **Single active operation marker.** Single-worker HTTP shares one operation
+  registry across all clients: `recent_operations` reports one active
+  operation at a time and its history is visible to every connected client
+  (including target file paths). Concurrent clients can each see the other's
+  operations misattributed as the active one during timeout triage.
+- **No task enumeration.** The MCP tasks extension (SEP-2663) defines
+  `tasks/get`, `tasks/update`, and `tasks/cancel` only. Clients that used the
+  experimental `tasks/list` / `tasks/result` methods from pre-3.0 rmcp SDKs
+  must retain the `task_id` returned by the spawning tool call; a task whose
+  id is lost can only be waited out.
+- **Bounded task retention.** The server retains up to 256 running and terminal
+  tasks. Terminal results normally remain available for the advertised 24-hour
+  TTL, but the TTL is an upper bound, not a guarantee: when the registry hits
+  its cap, admitting new background work reclaims the least recently updated
+  terminal results early. Running tasks are never reclaimed, so a registry
+  full of in-flight work still rejects new background work until something
+  settles. Fetch results promptly rather than relying on the full TTL.
 
 ## Shutdown
 

--- a/justfile
+++ b/justfile
@@ -9,12 +9,16 @@ build:
     cargo build
 
 # Build release binary
+# KACHE_DISABLED=1: kache 0.13.0 restore-time mtime bugs can leave a stale
+# binary while reporting success (kunobi-ninja/kache#677/#680/#682, fixed
+# upstream 2026-08-08). Release artifacts bypass the cache until a fixed
+# kache release ships; day-to-day debug builds keep it for disk savings.
 release:
-    cargo build --release
+    KACHE_DISABLED=1 cargo build --release
 
 # Build release binary linked against a specific IDA version (local testing, no publish)
 release-against ida_version="9.4":
-    IDADIR="/Applications/IDA Professional {{ ida_version }}.app/Contents/MacOS" cargo build --release
+    KACHE_DISABLED=1 IDADIR="/Applications/IDA Professional {{ ida_version }}.app/Contents/MacOS" cargo build --release
 
 # Build and publish prerelease (macOS ARM64 only, for local testing)
 prerelease ida_version="9.4": && (update-beta-cask ida_version)
@@ -22,7 +26,7 @@ prerelease ida_version="9.4": && (update-beta-cask ida_version)
     set -euo pipefail
     VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
     TARGET=$(git rev-parse HEAD)
-    IDADIR="/Applications/IDA Professional {{ ida_version }}.app/Contents/MacOS" cargo build --release
+    KACHE_DISABLED=1 IDADIR="/Applications/IDA Professional {{ ida_version }}.app/Contents/MacOS" cargo build --release
     mkdir -p dist
     rm -f "dist/ida-mcp_${VERSION}_Darwin_arm64.tar.gz"
     tar -czvf "dist/ida-mcp_${VERSION}_Darwin_arm64.tar.gz" -C target/release ida-mcp -C "{{ justfile_directory() }}" README.md LICENSE
@@ -150,6 +154,14 @@ test-http: build
 test-http-recovery: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-http-recovery
 
+# Run legacy-session cancel-on-disconnect test (single-worker HTTP)
+test-session-cancel: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-session-cancel
+
+# Run HTTP startup-failure test (no IDA license or fixture required)
+test-http-startup: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp just test-http-startup
+
 # Run HTTP worker-pool concurrency test (debug)
 test-pool: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-pool
@@ -189,6 +201,10 @@ test-observability: build
 # Run open_idb auto-background elicitation integration test (debug)
 test-elicitation: build
     cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-elicitation
+
+# Verify MCP 2026 discover/stateless lifecycle and the pooled legacy boundary.
+test-modern: build
+    cd test && SERVER_BIN=../target/debug/ida-mcp RUST_LOG=ida_mcp=trace just test-modern
 
 # Run open_idb rebuild semantics test (raw reuse vs rebuild=true overwrite)
 test-rebuild-idb: build

--- a/src/bin/gen_tools_doc.rs
+++ b/src/bin/gen_tools_doc.rs
@@ -75,7 +75,7 @@ fn main() {
     );
     let _ = writeln!(
         out,
-        "- Call `close_idb` when done to release locks; in multi-client servers coordinate before closing (HTTP/SSE requires close_token from open_idb)"
+        "- Call `close_idb` when done to release locks; in multi-client servers coordinate before closing (HTTP/SSE requires the close_token from `open_idb` unless the request is in the owning legacy session)"
     );
     let _ = writeln!(out);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,22 @@ pub enum ToolError {
     Busy,
 
     #[error(
+        "The database this background operation opened was closed and replaced. \
+         Its remaining work was abandoned so it cannot touch the current database."
+    )]
+    DatabaseReplaced,
+
+    #[error(
+        "Matching background work is already running; its task handle stays with the response that started it. Retry after it finishes."
+    )]
+    BackgroundTaskHandlePrivate,
+
+    #[error(
+        "Background task registry is full ({max} retained tasks). Retry after older results expire."
+    )]
+    BackgroundTaskRegistryFull { max: usize },
+
+    #[error(
         "Worker pool exhausted: {active}/{max} workers are leased. Close an IDB or retry later."
     )]
     PoolExhausted { active: usize, max: usize },

--- a/src/ida/loop_impl.rs
+++ b/src/ida/loop_impl.rs
@@ -23,6 +23,7 @@ use crate::ida::observability::{
 #[cfg(target_os = "windows")]
 use crate::ida::registry_isolation::IsolatedWindowsRegistry;
 use crate::ida::request::IdaRequest;
+use crate::ida::types::{ConditionalCloseResult, DatabaseGeneration, OpenedDatabase};
 
 const AUTO_USE_LUMINA_REGISTRY_VALUE: &str = "AutoUseLumina";
 
@@ -504,6 +505,8 @@ fn init_ida_library_with_isolated_idausr(
 /// This function blocks until Shutdown is received.
 pub fn run_ida_loop(rx: mpsc::Receiver<IdaRequest>, init_state: IdaInitState) {
     let mut idb: Option<IDB> = None;
+    let mut database_generation: Option<DatabaseGeneration> = None;
+    let mut next_database_generation = 0_u64;
     let mut lock_file: Option<File> = None;
     let mut lock_path: Option<PathBuf> = None;
     let mut lib_initialized = init_state.library_initialized;
@@ -595,6 +598,7 @@ pub fn run_ida_loop(rx: mpsc::Receiver<IdaRequest>, init_state: IdaInitState) {
                     continue;
                 }
                 info!(path = %path, force, rebuild, file_type = ?file_type, auto_analyse, "Opening database");
+                let had_open_database = idb.is_some();
                 let result = database::handle_open(
                     &mut idb,
                     &mut lock_file,
@@ -612,20 +616,40 @@ pub fn run_ida_loop(rx: mpsc::Receiver<IdaRequest>, init_state: IdaInitState) {
                     progress_tx.clone(),
                     cancel.clone(),
                 );
+                let result = result.and_then(|info| {
+                    let generation = match database_generation {
+                        Some(generation) if had_open_database => generation,
+                        _ => {
+                            let Some(next) = next_database_generation.checked_add(1) else {
+                                drop(idb.take());
+                                release_mcp_lock(&mut lock_file, &mut lock_path);
+                                return Err(ToolError::IdaError(
+                                    "database generation counter exhausted".to_string(),
+                                ));
+                            };
+                            next_database_generation = next;
+                            let generation = DatabaseGeneration(next);
+                            database_generation = Some(generation);
+                            generation
+                        }
+                    };
+                    Ok(OpenedDatabase { info, generation })
+                });
                 match &result {
-                    Ok(info) => {
+                    Ok(opened) => {
                         emit_progress(
                             progress_tx.as_ref(),
                             "completed",
                             OPEN_IDB_PROGRESS_TOTAL,
                             Some(OPEN_IDB_PROGRESS_TOTAL),
-                            format!("Opened database {}", info.path),
+                            format!("Opened database {}", opened.info.path),
                         );
                         info!(
-                            path = %info.path,
-                            processor = %info.processor,
-                            bits = info.bits,
-                            functions = info.function_count,
+                            path = %opened.info.path,
+                            processor = %opened.info.processor,
+                            bits = opened.info.bits,
+                            functions = opened.info.function_count,
+                            database_generation = opened.generation.0,
                             "Database opened"
                         );
                     }
@@ -658,9 +682,29 @@ pub fn run_ida_loop(rx: mpsc::Receiver<IdaRequest>, init_state: IdaInitState) {
                     info!(path = %db.path().display(), "Dropping IDB (will call close_database_with(save))");
                 }
                 drop(idb.take());
+                database_generation = None;
                 info!("IDB dropped, database should be packed");
                 release_mcp_lock(&mut lock_file, &mut lock_path);
                 let _ = resp.send(());
+            }
+            IdaRequest::CloseIfGeneration { generation, resp } => {
+                if database_generation == Some(generation) {
+                    info!(
+                        database_generation = generation.0,
+                        "Closing matching database generation"
+                    );
+                    drop(idb.take());
+                    database_generation = None;
+                    release_mcp_lock(&mut lock_file, &mut lock_path);
+                    let _ = resp.send(Ok(ConditionalCloseResult::Closed));
+                } else {
+                    debug!(
+                        expected_generation = generation.0,
+                        current_generation = database_generation.map(|current| current.0),
+                        "Skipping conditional close for a stale database generation"
+                    );
+                    let _ = resp.send(Ok(ConditionalCloseResult::NotCurrent));
+                }
             }
             IdaRequest::LoadDebugInfo {
                 path,
@@ -677,7 +721,14 @@ pub fn run_ida_loop(rx: mpsc::Receiver<IdaRequest>, init_state: IdaInitState) {
                 }
                 let _ = resp.send(result);
             }
-            IdaRequest::AnalysisStatus { resp } => {
+            IdaRequest::AnalysisStatus {
+                expected_generation,
+                resp,
+            } => {
+                if let Err(err) = require_generation(expected_generation, database_generation) {
+                    let _ = resp.send(Err(err));
+                    continue;
+                }
                 debug!("Reporting analysis status");
                 let result = crate::crash_guard::crash_guarded("handle_analysis_status", || {
                     analysis::handle_analysis_status(&idb)
@@ -693,7 +744,15 @@ pub fn run_ida_loop(rx: mpsc::Receiver<IdaRequest>, init_state: IdaInitState) {
                 }
                 let _ = resp.send(result);
             }
-            IdaRequest::DscLoadImage { module, resp } => {
+            IdaRequest::DscLoadImage {
+                module,
+                expected_generation,
+                resp,
+            } => {
+                if let Err(err) = require_generation(expected_generation, database_generation) {
+                    let _ = resp.send(Err(err));
+                    continue;
+                }
                 debug!(module = %module, "Loading DSC image");
                 let result = crate::crash_guard::crash_guarded("handle_dsc_load_image", || {
                     dscu::handle_dsc_load_image(&idb, &module)
@@ -1861,6 +1920,31 @@ fn shutdown_cleanup(
 
 /// Send a version-mismatch error for every request variant so the
 /// agent gets a clear message instead of a segfault.
+/// Refuse an operation whose caller opened a database that is no longer the
+/// current one. `None` opts out (foreground tools legitimately target whatever
+/// database is open); `Some` binds the operation to one database lifetime.
+///
+/// This must be evaluated in the same loop iteration that performs the work:
+/// the worker dequeues serially, so an "assert generation" request followed by
+/// a separate operation request would let a close/reopen slip between them.
+fn require_generation(
+    expected: Option<DatabaseGeneration>,
+    current: Option<DatabaseGeneration>,
+) -> Result<(), ToolError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    if current == Some(expected) {
+        return Ok(());
+    }
+    warn!(
+        expected_generation = expected.0,
+        current_generation = current.map(|generation| generation.0),
+        "Refusing an operation bound to a replaced database generation"
+    );
+    Err(ToolError::DatabaseReplaced)
+}
+
 fn reject_with_version_error(req: IdaRequest, msg: &str) {
     reject_with_error(req, ToolError::SdkVersionMismatch(msg.to_owned()));
 }
@@ -1878,6 +1962,7 @@ fn reject_with_error(req: IdaRequest, err: ToolError) {
         IdaRequest::Close { resp } => {
             let _ = resp.send(());
         }
+        IdaRequest::CloseIfGeneration { resp, .. } => reject!(resp, err),
         IdaRequest::Open { resp, .. } => reject!(resp, err),
         IdaRequest::LoadDebugInfo { resp, .. } => reject!(resp, err),
         IdaRequest::AnalysisStatus { resp, .. } => reject!(resp, err),
@@ -1968,9 +2053,43 @@ mod tests {
     use std::ffi::OsStr;
     use std::path::{Path, PathBuf};
 
+    use crate::error::ToolError;
     use crate::ida::loop_impl::{
-        check_version_mismatch, configure_lumina, first_ida_user_dir, should_check_license_expiry,
+        check_version_mismatch, configure_lumina, first_ida_user_dir, require_generation,
+        should_check_license_expiry,
     };
+    use crate::ida::types::DatabaseGeneration;
+
+    #[test]
+    fn unbound_operations_target_whatever_database_is_open() {
+        // Foreground tools legitimately act on the current database.
+        assert!(require_generation(None, Some(DatabaseGeneration(7))).is_ok());
+        assert!(require_generation(None, None).is_ok());
+    }
+
+    #[test]
+    fn bound_operation_runs_against_the_database_it_opened() {
+        assert!(
+            require_generation(Some(DatabaseGeneration(7)), Some(DatabaseGeneration(7))).is_ok()
+        );
+    }
+
+    /// The close/reopen race: a background task opened generation N, another
+    /// request closed it and opened N+1, and the task's remaining work must be
+    /// refused instead of silently redirected onto the new database.
+    #[test]
+    fn bound_operation_is_refused_after_a_close_and_reopen() {
+        let err = require_generation(Some(DatabaseGeneration(1)), Some(DatabaseGeneration(2)))
+            .expect_err("a replaced database must refuse the stale operation");
+        assert!(matches!(err, ToolError::DatabaseReplaced), "{err}");
+    }
+
+    #[test]
+    fn bound_operation_is_refused_after_a_plain_close() {
+        let err = require_generation(Some(DatabaseGeneration(1)), None)
+            .expect_err("a closed database must refuse the stale operation");
+        assert!(matches!(err, ToolError::DatabaseReplaced), "{err}");
+    }
 
     #[test]
     fn matching_ida_94_version_passes() {

--- a/src/ida/pool.rs
+++ b/src/ida/pool.rs
@@ -18,6 +18,7 @@ use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
@@ -818,8 +819,15 @@ impl PooledWorkerHandle {
 pub struct PooledSessionState {
     pool: WorkerPool,
     session_id: String,
-    handle: Arc<Mutex<Option<PooledWorkerHandle>>>,
+    handle: Arc<Mutex<Option<PooledDatabaseLease>>>,
+    next_database_generation: AtomicU64,
     runtime: Option<Handle>,
+}
+
+#[derive(Clone)]
+struct PooledDatabaseLease {
+    handle: PooledWorkerHandle,
+    generation: DatabaseGeneration,
 }
 
 impl PooledSessionState {
@@ -828,32 +836,66 @@ impl PooledSessionState {
             pool,
             session_id,
             handle: Arc::new(Mutex::new(None)),
+            next_database_generation: AtomicU64::new(0),
             runtime: Handle::try_current().ok(),
         }
     }
 
-    async fn lease_for_open(&self) -> Result<(PooledWorkerHandle, bool), ToolError> {
+    fn next_database_generation(&self) -> Result<DatabaseGeneration, ToolError> {
+        let previous = self
+            .next_database_generation
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .map_err(|_| {
+                ToolError::IdaError("database generation counter exhausted".to_string())
+            })?;
+        previous
+            .checked_add(1)
+            .map(DatabaseGeneration)
+            .ok_or_else(|| ToolError::IdaError("database generation counter exhausted".to_string()))
+    }
+
+    async fn lease_for_open(
+        &self,
+    ) -> Result<(PooledWorkerHandle, DatabaseGeneration, bool), ToolError> {
         let mut guard = self.handle.lock().await;
-        if let Some(handle) = guard.as_ref() {
-            return Ok((handle.clone(), false));
+        if let Some(lease) = guard.as_ref() {
+            return Ok((lease.handle.clone(), lease.generation, false));
         }
+        let generation = self.next_database_generation()?;
         let handle = self.pool.lease(&self.session_id).await?;
-        *guard = Some(handle.clone());
-        Ok((handle, true))
+        *guard = Some(PooledDatabaseLease {
+            handle: handle.clone(),
+            generation,
+        });
+        Ok((handle, generation, true))
     }
 
-    async fn required_handle(&self) -> Result<PooledWorkerHandle, ToolError> {
+    /// Resolve the leased worker, optionally only while `expected_generation`
+    /// is still this session's database lifetime.
+    ///
+    /// The generation comparison and the handle clone happen under one lock
+    /// acquisition: a `close_idb` that replaces the lease either loses the race
+    /// (we dispatch against the database we opened) or wins it (we refuse). A
+    /// caller that checked separately could be redirected onto the new lease.
+    async fn required_handle_for_generation(
+        &self,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<PooledWorkerHandle, ToolError> {
         let guard = self.handle.lock().await;
-        guard.as_ref().cloned().ok_or(ToolError::NoDatabaseOpen)
+        let lease = guard.as_ref().ok_or(ToolError::NoDatabaseOpen)?;
+        require_lease_generation(lease.generation, expected_generation)?;
+        Ok(lease.handle.clone())
     }
 
-    async fn take_handle(&self) -> Option<PooledWorkerHandle> {
+    async fn take_handle(&self) -> Option<PooledDatabaseLease> {
         self.handle.lock().await.take()
     }
 
     async fn release_current_handle(&self) {
-        if let Some(handle) = self.take_handle().await {
-            let _ = self.pool.release(handle).await;
+        if let Some(lease) = self.take_handle().await {
+            let _ = self.pool.release(lease.handle).await;
         }
     }
 
@@ -861,20 +903,25 @@ impl PooledSessionState {
         let mut guard = self.handle.lock().await;
         if guard
             .as_ref()
-            .is_some_and(|handle| handle.worker_id == worker_id)
+            .is_some_and(|lease| lease.handle.worker_id == worker_id)
         {
             *guard = None;
         }
     }
 
-    async fn call_result(
+    /// Call a child tool, optionally bound to one database lifetime (see
+    /// [`Self::required_handle_for_generation`]).
+    async fn call_result_for_generation(
         &self,
         tool: &'static str,
         args: Value,
         timeout_secs: Option<u64>,
         cancel: Option<CancellationToken>,
+        expected_generation: Option<DatabaseGeneration>,
     ) -> Result<CallToolResult, ToolError> {
-        let handle = self.required_handle().await?;
+        let handle = self
+            .required_handle_for_generation(expected_generation)
+            .await?;
         let timeout = self.pool.worker_op_timeout(timeout_secs);
         match handle
             .call_tool(tool, remote::json_object(args)?, timeout, cancel)
@@ -904,7 +951,21 @@ impl PooledSessionState {
         timeout_secs: Option<u64>,
         cancel: Option<CancellationToken>,
     ) -> Result<T, ToolError> {
-        let result = self.call_result(tool, args, timeout_secs, cancel).await?;
+        self.call_json_for_generation(tool, args, timeout_secs, cancel, None)
+            .await
+    }
+
+    async fn call_json_for_generation<T: DeserializeOwned>(
+        &self,
+        tool: &'static str,
+        args: Value,
+        timeout_secs: Option<u64>,
+        cancel: Option<CancellationToken>,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<T, ToolError> {
+        let result = self
+            .call_result_for_generation(tool, args, timeout_secs, cancel, expected_generation)
+            .await?;
         remote::parse_json(result, tool)
     }
 
@@ -915,7 +976,21 @@ impl PooledSessionState {
         timeout_secs: Option<u64>,
         cancel: Option<CancellationToken>,
     ) -> Result<Value, ToolError> {
-        let result = self.call_result(tool, args, timeout_secs, cancel).await?;
+        self.call_value_for_generation(tool, args, timeout_secs, cancel, None)
+            .await
+    }
+
+    async fn call_value_for_generation(
+        &self,
+        tool: &'static str,
+        args: Value,
+        timeout_secs: Option<u64>,
+        cancel: Option<CancellationToken>,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<Value, ToolError> {
+        let result = self
+            .call_result_for_generation(tool, args, timeout_secs, cancel, expected_generation)
+            .await?;
         remote::parse_value(result, tool)
     }
 
@@ -926,7 +1001,21 @@ impl PooledSessionState {
         field: &'static str,
         timeout_secs: Option<u64>,
     ) -> Result<T, ToolError> {
-        let value = self.call_value(tool, args, timeout_secs, None).await?;
+        self.call_json_field_for_generation(tool, args, field, timeout_secs, None)
+            .await
+    }
+
+    async fn call_json_field_for_generation<T: DeserializeOwned>(
+        &self,
+        tool: &'static str,
+        args: Value,
+        field: &'static str,
+        timeout_secs: Option<u64>,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<T, ToolError> {
+        let value = self
+            .call_value_for_generation(tool, args, timeout_secs, None, expected_generation)
+            .await?;
         let Some(field_value) = value.get(field).cloned() else {
             return Err(ToolError::RemoteProtocol(format!(
                 "child tool {tool} response did not contain `{field}`"
@@ -944,7 +1033,9 @@ impl PooledSessionState {
         timeout_secs: Option<u64>,
         cancel: Option<CancellationToken>,
     ) -> Result<String, ToolError> {
-        let result = self.call_result(tool, args, timeout_secs, cancel).await?;
+        let result = self
+            .call_result_for_generation(tool, args, timeout_secs, cancel, None)
+            .await?;
         remote::result_text(&result, tool)
     }
 
@@ -965,7 +1056,43 @@ impl PooledSessionState {
         _progress_tx: Option<ProgressSender>,
         cancel: Option<CancellationToken>,
     ) -> Result<DbInfo, ToolError> {
-        let (handle, fresh_lease) = self.lease_for_open().await?;
+        self.open_observed_with_generation(
+            path,
+            load_debug_info,
+            debug_info_path,
+            debug_info_verbose,
+            force,
+            rebuild,
+            file_type,
+            auto_analyse,
+            extra_args,
+            idb_out,
+            timeout_secs,
+            _progress_tx,
+            cancel,
+        )
+        .await
+        .map(|opened| opened.info)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn open_observed_with_generation(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        rebuild: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+        idb_out: Option<String>,
+        timeout_secs: Option<u64>,
+        _progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<OpenedDatabase, ToolError> {
+        let (handle, generation, fresh_lease) = self.lease_for_open().await?;
         let timeout = self.pool.worker_op_timeout(timeout_secs);
         let result = handle
             .call_tool(
@@ -992,7 +1119,7 @@ impl PooledSessionState {
             Ok(info) => {
                 let mut child = handle.slot.child.lock().await;
                 child.idb_path = Some(PathBuf::from(&info.path));
-                Ok(info)
+                Ok(OpenedDatabase { info, generation })
             }
             Err(err) => {
                 if open_error_releases_lease(fresh_lease, &err) {
@@ -1003,42 +1130,32 @@ impl PooledSessionState {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub async fn open(
-        &self,
-        path: &str,
-        load_debug_info: bool,
-        debug_info_path: Option<String>,
-        debug_info_verbose: bool,
-        force: bool,
-        rebuild: bool,
-        file_type: Option<String>,
-        auto_analyse: bool,
-        extra_args: Vec<String>,
-    ) -> Result<DbInfo, ToolError> {
-        self.open_observed(
-            path,
-            load_debug_info,
-            debug_info_path,
-            debug_info_verbose,
-            force,
-            rebuild,
-            file_type,
-            auto_analyse,
-            extra_args,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await
-    }
-
     pub async fn close(&self) -> Result<(), ToolError> {
-        let Some(handle) = self.take_handle().await else {
+        let Some(lease) = self.take_handle().await else {
             return Err(ToolError::NoDatabaseOpen);
         };
-        self.pool.release(handle).await
+        self.pool.release(lease.handle).await
+    }
+
+    pub(crate) async fn close_if_generation(
+        &self,
+        generation: DatabaseGeneration,
+    ) -> Result<ConditionalCloseResult, ToolError> {
+        let lease = {
+            let mut guard = self.handle.lock().await;
+            if guard
+                .as_ref()
+                .is_none_or(|lease| lease.generation != generation)
+            {
+                return Ok(ConditionalCloseResult::NotCurrent);
+            }
+            guard.take()
+        };
+        let Some(lease) = lease else {
+            return Ok(ConditionalCloseResult::NotCurrent);
+        };
+        self.pool.release(lease.handle).await?;
+        Ok(ConditionalCloseResult::Closed)
     }
 
     pub async fn load_debug_info(
@@ -1056,8 +1173,21 @@ impl PooledSessionState {
     }
 
     pub async fn analysis_status(&self) -> Result<AnalysisStatus, ToolError> {
-        self.call_json("analysis_status", json!({}), None, None)
-            .await
+        self.analysis_status_for_generation(None).await
+    }
+
+    pub(crate) async fn analysis_status_for_generation(
+        &self,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<AnalysisStatus, ToolError> {
+        self.call_json_for_generation(
+            "analysis_status",
+            json!({}),
+            None,
+            None,
+            expected_generation,
+        )
+        .await
     }
 
     pub async fn dsc_load_image(
@@ -1065,11 +1195,22 @@ impl PooledSessionState {
         module: &str,
         timeout_secs: Option<u64>,
     ) -> Result<DscImageInfo, ToolError> {
-        self.call_json_field(
+        self.dsc_load_image_for_generation(module, timeout_secs, None)
+            .await
+    }
+
+    pub(crate) async fn dsc_load_image_for_generation(
+        &self,
+        module: &str,
+        timeout_secs: Option<u64>,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<DscImageInfo, ToolError> {
+        self.call_json_field_for_generation(
             "dsc_add_dylib",
             json!({ "module": module, "timeout_secs": timeout_secs }),
             "image",
             timeout_secs,
+            expected_generation,
         )
         .await
     }
@@ -1957,10 +2098,10 @@ impl Drop for PooledSessionState {
             return;
         };
         runtime.spawn(async move {
-            let Some(handle) = handle_slot.lock().await.take() else {
+            let Some(lease) = handle_slot.lock().await.take() else {
                 return;
             };
-            let _ = pool.release(handle).await;
+            let _ = pool.release(lease.handle).await;
         });
     }
 }
@@ -2081,6 +2222,32 @@ fn extract_first_matches(value: Value, tool: &'static str) -> Result<Value, Tool
     Ok(json!({ "matches": matches }))
 }
 
+/// Decide whether an operation bound to `expected` may run against the lease
+/// currently held at `current`.
+///
+/// `None` opts out, for foreground tools that legitimately target whatever
+/// database the session has open. `Some` binds the operation to one database
+/// lifetime so a close/reopen refuses it instead of redirecting it onto the
+/// new lease. The caller evaluates this while holding the lease lock, so the
+/// decision cannot be invalidated between here and dispatch.
+fn require_lease_generation(
+    current: DatabaseGeneration,
+    expected: Option<DatabaseGeneration>,
+) -> Result<(), ToolError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    if current == expected {
+        return Ok(());
+    }
+    warn!(
+        expected_generation = expected.0,
+        current_generation = current.0,
+        "Refusing a pooled operation bound to a replaced database generation"
+    );
+    Err(ToolError::DatabaseReplaced)
+}
+
 fn release_error_retires_worker(err: &ToolError) -> bool {
     matches!(
         err,
@@ -2171,9 +2338,10 @@ mod tests {
     use crate::ida::pool::{
         analyze_funcs_child_args, child_tool_error_retires_worker, extract_first_matches,
         find_bytes_child_args, lumina_apply_child_args, open_error_releases_lease,
-        open_idb_child_args, release_error_retires_worker, run_script_child_args,
-        search_child_args, WorkerPool, WorkerPoolConfig,
+        open_idb_child_args, release_error_retires_worker, require_lease_generation,
+        run_script_child_args, search_child_args, WorkerPool, WorkerPoolConfig,
     };
+    use crate::ida::types::{ConditionalCloseResult, DatabaseGeneration};
     use serde_json::json;
     use std::path::PathBuf;
     use std::time::Duration;
@@ -2345,6 +2513,64 @@ mod tests {
                 worker_id: 7,
                 last_op: "open_idb".to_string(),
             }
+        ));
+    }
+
+    #[tokio::test]
+    async fn conditional_close_without_matching_pooled_generation_is_a_noop() {
+        let state =
+            crate::ida::pool::PooledSessionState::new(test_pool(1), "generation-test".to_string());
+
+        assert_eq!(
+            state
+                .close_if_generation(DatabaseGeneration(1))
+                .await
+                .expect("a missing generation should be a successful no-op"),
+            ConditionalCloseResult::NotCurrent
+        );
+    }
+
+    /// The close/reopen redirect: a background task holds the generation it
+    /// opened, its session closes and reopens, and the task's next post-open
+    /// call must be refused rather than resolved against the new lease.
+    ///
+    /// Every pooled post-open call resolves its worker through
+    /// `required_handle_for_generation`, which applies this decision while
+    /// holding the lease lock, so a concurrent close cannot slip between the
+    /// check and the dispatch.
+    #[test]
+    fn post_open_call_is_refused_after_its_lease_is_replaced() {
+        let opened = DatabaseGeneration(1);
+        let after_reopen = DatabaseGeneration(2);
+
+        // The task's own database: its remaining work proceeds.
+        assert!(require_lease_generation(opened, Some(opened)).is_ok());
+
+        // After a close/reopen the lease names a different database; the stale
+        // task must be refused instead of silently mutating the new one.
+        match require_lease_generation(after_reopen, Some(opened)) {
+            Err(ToolError::DatabaseReplaced) => {}
+            Err(other) => panic!("expected DatabaseReplaced, got {other}"),
+            Ok(()) => panic!("a replaced lease must refuse the stale operation"),
+        }
+
+        // The session that owns the new database is unaffected.
+        assert!(require_lease_generation(after_reopen, Some(after_reopen)).is_ok());
+
+        // Foreground tools opt out and follow the current lease.
+        assert!(require_lease_generation(after_reopen, None).is_ok());
+    }
+
+    #[tokio::test]
+    async fn bound_call_reports_no_database_rather_than_a_redirect() {
+        let state =
+            crate::ida::pool::PooledSessionState::new(test_pool(1), "redirect-test".to_string());
+
+        assert!(matches!(
+            state
+                .required_handle_for_generation(Some(DatabaseGeneration(1)))
+                .await,
+            Err(ToolError::NoDatabaseOpen)
         ));
     }
 

--- a/src/ida/request.rs
+++ b/src/ida/request.rs
@@ -22,10 +22,14 @@ pub enum IdaRequest {
         idb_out: Option<String>,
         progress_tx: Option<ProgressSender>,
         cancel: Option<CancellationToken>,
-        resp: oneshot::Sender<Result<DbInfo, ToolError>>,
+        resp: oneshot::Sender<Result<OpenedDatabase, ToolError>>,
     },
     Close {
         resp: oneshot::Sender<()>,
+    },
+    CloseIfGeneration {
+        generation: DatabaseGeneration,
+        resp: oneshot::Sender<Result<ConditionalCloseResult, ToolError>>,
     },
     LoadDebugInfo {
         path: Option<String>,
@@ -33,10 +37,18 @@ pub enum IdaRequest {
         resp: oneshot::Sender<Result<Value, ToolError>>,
     },
     AnalysisStatus {
+        /// When set, the request is refused unless this database lifetime is
+        /// still current, so a background task cannot observe the database
+        /// that replaced the one it opened.
+        expected_generation: Option<DatabaseGeneration>,
         resp: oneshot::Sender<Result<AnalysisStatus, ToolError>>,
     },
     DscLoadImage {
         module: String,
+        /// See [`IdaRequest::AnalysisStatus::expected_generation`]. Loading an
+        /// image mutates the database, so a stale task must be refused before
+        /// it writes into a database it does not own.
+        expected_generation: Option<DatabaseGeneration>,
         resp: oneshot::Sender<Result<DscImageInfo, ToolError>>,
     },
     DscLoadRegion {

--- a/src/ida/types.rs
+++ b/src/ida/types.rs
@@ -14,6 +14,31 @@ pub struct DbInfo {
     pub analysis_status: AnalysisStatus,
 }
 
+/// Opaque identity for one database-open lifetime within a worker backend.
+///
+/// A background task captures this at open and passes it back for every later
+/// operation on that database, so a close/reopen cannot silently redirect the
+/// task's remaining work onto whatever database is current. It scopes both
+/// cleanup (a stale task may close the database it opened, never a newer one)
+/// and post-open work (a stale task must not read or mutate a newer one).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DatabaseGeneration(pub(crate) u64);
+
+/// Internal open result that carries the database lifetime identity without
+/// exposing it in the public MCP tool response.
+#[derive(Debug, Clone)]
+pub struct OpenedDatabase {
+    pub(crate) info: DbInfo,
+    pub(crate) generation: DatabaseGeneration,
+}
+
+/// Result of closing only when an expected database lifetime is still active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConditionalCloseResult {
+    Closed,
+    NotCurrent,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DebugInfoLoad {
     pub path: String,

--- a/src/ida/worker.rs
+++ b/src/ida/worker.rs
@@ -6,10 +6,8 @@ use crate::ida::pool::PooledSessionState;
 use crate::ida::request::IdaRequest;
 use crate::ida::types::*;
 use serde_json::Value;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::oneshot;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -44,20 +42,12 @@ pub(crate) enum CloseAuthorization {
 }
 
 /// Internal state for close token ownership.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct CloseTokenState {
     token: Mutex<Option<CloseTokenLease>>,
-    nonce: AtomicU64,
 }
 
 impl CloseTokenState {
-    fn new() -> Self {
-        Self {
-            token: Mutex::new(None),
-            nonce: AtomicU64::new(0),
-        }
-    }
-
     fn lock_token(&self) -> std::sync::MutexGuard<'_, Option<CloseTokenLease>> {
         match self.token.lock() {
             Ok(guard) => guard,
@@ -65,14 +55,8 @@ impl CloseTokenState {
         }
     }
 
-    fn generate_token(&self) -> String {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let nonce = self.nonce.fetch_add(1, Ordering::Relaxed);
-        let pid = std::process::id();
-        format!("{now:x}-{pid:x}-{nonce:x}")
+    fn generate_token() -> String {
+        uuid::Uuid::new_v4().simple().to_string()
     }
 
     fn issue_for_session(&self, session_id: &str) -> Result<CloseTokenGrant, String> {
@@ -88,7 +72,7 @@ impl CloseTokenState {
             return Err(lease.owner_session_id.clone());
         }
 
-        let token = self.generate_token();
+        let token = Self::generate_token();
         let lease = CloseTokenLease {
             token: token.clone(),
             owner_session_id: session_id.to_string(),
@@ -143,7 +127,7 @@ impl IdaWorker {
     pub fn new(tx: mpsc::SyncSender<IdaRequest>) -> Self {
         Self {
             tx,
-            close_token: Arc::new(CloseTokenState::new()),
+            close_token: Arc::new(CloseTokenState::default()),
         }
     }
 
@@ -219,39 +203,6 @@ impl IdaWorker {
         rx.await?
     }
 
-    /// Open an IDA database file.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn open(
-        &self,
-        path: &str,
-        load_debug_info: bool,
-        debug_info_path: Option<String>,
-        debug_info_verbose: bool,
-        force: bool,
-        rebuild: bool,
-        file_type: Option<String>,
-        auto_analyse: bool,
-        extra_args: Vec<String>,
-        idb_out: Option<String>,
-    ) -> Result<DbInfo, ToolError> {
-        self.open_observed(
-            path,
-            load_debug_info,
-            debug_info_path,
-            debug_info_verbose,
-            force,
-            rebuild,
-            file_type,
-            auto_analyse,
-            extra_args,
-            idb_out,
-            None,
-            None,
-            None,
-        )
-        .await
-    }
-
     /// Open an IDA database file and stream foreground progress updates.
     #[allow(clippy::too_many_arguments)]
     pub async fn open_observed(
@@ -270,6 +221,44 @@ impl IdaWorker {
         progress_tx: Option<ProgressSender>,
         cancel: Option<CancellationToken>,
     ) -> Result<DbInfo, ToolError> {
+        self.open_observed_with_generation(
+            path,
+            load_debug_info,
+            debug_info_path,
+            debug_info_verbose,
+            force,
+            rebuild,
+            file_type,
+            auto_analyse,
+            extra_args,
+            idb_out,
+            _timeout_secs,
+            progress_tx,
+            cancel,
+        )
+        .await
+        .map(|opened| opened.info)
+    }
+
+    /// Open a database and retain its worker-local lifetime identity for
+    /// generation-checked cleanup by background operations.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn open_observed_with_generation(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        rebuild: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+        idb_out: Option<String>,
+        _timeout_secs: Option<u64>,
+        progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<OpenedDatabase, ToolError> {
         let (tx, rx) = oneshot::channel();
         self.try_send(IdaRequest::Open {
             path: path.to_string(),
@@ -287,6 +276,28 @@ impl IdaWorker {
             resp: tx,
         })?;
         Self::recv(rx).await
+    }
+
+    /// Close the database only if it is still the lifetime opened by the
+    /// caller. A mismatch is a successful no-op.
+    pub(crate) async fn close_if_generation(
+        &self,
+        generation: DatabaseGeneration,
+    ) -> Result<ConditionalCloseResult, ToolError> {
+        let (tx, rx) = oneshot::channel();
+        self.send_with_retry(
+            IdaRequest::CloseIfGeneration {
+                generation,
+                resp: tx,
+            },
+            Some(Duration::from_secs(CLOSE_SEND_TIMEOUT_SECS)),
+        )
+        .await?;
+        let result = rx.await.map_err(|_| ToolError::WorkerClosed)??;
+        if result == ConditionalCloseResult::Closed {
+            self.clear_close_token();
+        }
+        Ok(result)
     }
 
     /// Close the currently open database.
@@ -324,8 +335,20 @@ impl IdaWorker {
 
     /// Report current auto-analysis status.
     pub async fn analysis_status(&self) -> Result<AnalysisStatus, ToolError> {
+        self.analysis_status_for_generation(None).await
+    }
+
+    /// Report analysis status, optionally only while `expected_generation` is
+    /// still the open database (see [`DatabaseGeneration`]).
+    pub async fn analysis_status_for_generation(
+        &self,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<AnalysisStatus, ToolError> {
         let (tx, rx) = oneshot::channel();
-        self.try_send(IdaRequest::AnalysisStatus { resp: tx })?;
+        self.try_send(IdaRequest::AnalysisStatus {
+            expected_generation,
+            resp: tx,
+        })?;
         rx.await?
     }
 
@@ -335,9 +358,22 @@ impl IdaWorker {
         module: &str,
         timeout_secs: Option<u64>,
     ) -> Result<DscImageInfo, ToolError> {
+        self.dsc_load_image_for_generation(module, timeout_secs, None)
+            .await
+    }
+
+    /// Load a DSC image, optionally only while `expected_generation` is still
+    /// the open database (see [`DatabaseGeneration`]).
+    pub async fn dsc_load_image_for_generation(
+        &self,
+        module: &str,
+        timeout_secs: Option<u64>,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<DscImageInfo, ToolError> {
         let (tx, rx) = oneshot::channel();
         self.try_send(IdaRequest::DscLoadImage {
             module: module.to_string(),
+            expected_generation,
             resp: tx,
         })?;
         Self::recv_with_timeout(rx, timeout_secs).await
@@ -1325,54 +1361,6 @@ impl WorkerBackend {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub async fn open(
-        &self,
-        path: &str,
-        load_debug_info: bool,
-        debug_info_path: Option<String>,
-        debug_info_verbose: bool,
-        force: bool,
-        rebuild: bool,
-        file_type: Option<String>,
-        auto_analyse: bool,
-        extra_args: Vec<String>,
-    ) -> Result<DbInfo, ToolError> {
-        match self {
-            Self::Local(worker) => {
-                worker
-                    .open(
-                        path,
-                        load_debug_info,
-                        debug_info_path,
-                        debug_info_verbose,
-                        force,
-                        rebuild,
-                        file_type,
-                        auto_analyse,
-                        extra_args,
-                        None,
-                    )
-                    .await
-            }
-            Self::Pooled(state) => {
-                state
-                    .open(
-                        path,
-                        load_debug_info,
-                        debug_info_path,
-                        debug_info_verbose,
-                        force,
-                        rebuild,
-                        file_type,
-                        auto_analyse,
-                        extra_args,
-                    )
-                    .await
-            }
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
     pub async fn open_observed(
         &self,
         path: &str,
@@ -1389,10 +1377,46 @@ impl WorkerBackend {
         progress_tx: Option<ProgressSender>,
         cancel: Option<CancellationToken>,
     ) -> Result<DbInfo, ToolError> {
+        self.open_observed_with_generation(
+            path,
+            load_debug_info,
+            debug_info_path,
+            debug_info_verbose,
+            force,
+            rebuild,
+            file_type,
+            auto_analyse,
+            extra_args,
+            idb_out,
+            timeout_secs,
+            progress_tx,
+            cancel,
+        )
+        .await
+        .map(|opened| opened.info)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn open_observed_with_generation(
+        &self,
+        path: &str,
+        load_debug_info: bool,
+        debug_info_path: Option<String>,
+        debug_info_verbose: bool,
+        force: bool,
+        rebuild: bool,
+        file_type: Option<String>,
+        auto_analyse: bool,
+        extra_args: Vec<String>,
+        idb_out: Option<String>,
+        timeout_secs: Option<u64>,
+        progress_tx: Option<ProgressSender>,
+        cancel: Option<CancellationToken>,
+    ) -> Result<OpenedDatabase, ToolError> {
         match self {
             Self::Local(worker) => {
                 worker
-                    .open_observed(
+                    .open_observed_with_generation(
                         path,
                         load_debug_info,
                         debug_info_path,
@@ -1411,7 +1435,7 @@ impl WorkerBackend {
             }
             Self::Pooled(state) => {
                 state
-                    .open_observed(
+                    .open_observed_with_generation(
                         path,
                         load_debug_info,
                         debug_info_path,
@@ -1428,6 +1452,16 @@ impl WorkerBackend {
                     )
                     .await
             }
+        }
+    }
+
+    pub(crate) async fn close_if_generation(
+        &self,
+        generation: DatabaseGeneration,
+    ) -> Result<ConditionalCloseResult, ToolError> {
+        match self {
+            Self::Local(worker) => worker.close_if_generation(generation).await,
+            Self::Pooled(state) => state.close_if_generation(generation).await,
         }
     }
 
@@ -1464,9 +1498,25 @@ impl WorkerBackend {
     }
 
     pub async fn analysis_status(&self) -> Result<AnalysisStatus, ToolError> {
+        self.analysis_status_for_generation(None).await
+    }
+
+    /// See [`IdaWorker::analysis_status_for_generation`].
+    pub async fn analysis_status_for_generation(
+        &self,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<AnalysisStatus, ToolError> {
         match self {
-            Self::Local(worker) => worker.analysis_status().await,
-            Self::Pooled(state) => state.analysis_status().await,
+            Self::Local(worker) => {
+                worker
+                    .analysis_status_for_generation(expected_generation)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .analysis_status_for_generation(expected_generation)
+                    .await
+            }
         }
     }
 
@@ -1475,9 +1525,28 @@ impl WorkerBackend {
         module: &str,
         timeout_secs: Option<u64>,
     ) -> Result<DscImageInfo, ToolError> {
+        self.dsc_load_image_for_generation(module, timeout_secs, None)
+            .await
+    }
+
+    /// See [`IdaWorker::dsc_load_image_for_generation`].
+    pub async fn dsc_load_image_for_generation(
+        &self,
+        module: &str,
+        timeout_secs: Option<u64>,
+        expected_generation: Option<DatabaseGeneration>,
+    ) -> Result<DscImageInfo, ToolError> {
         match self {
-            Self::Local(worker) => worker.dsc_load_image(module, timeout_secs).await,
-            Self::Pooled(state) => state.dsc_load_image(module, timeout_secs).await,
+            Self::Local(worker) => {
+                worker
+                    .dsc_load_image_for_generation(module, timeout_secs, expected_generation)
+                    .await
+            }
+            Self::Pooled(state) => {
+                state
+                    .dsc_load_image_for_generation(module, timeout_secs, expected_generation)
+                    .await
+            }
         }
     }
 
@@ -2317,6 +2386,60 @@ mod tests {
         IdaWorker::new(tx)
     }
 
+    /// Wiring oracle: the generation a caller binds must reach the worker
+    /// request, where the loop compares it. Without this, the `_for_generation`
+    /// call sites could silently degrade to unbound and every other test would
+    /// still pass.
+    #[tokio::test]
+    async fn bound_post_open_calls_carry_their_generation_to_the_worker() {
+        use crate::ida::types::DatabaseGeneration;
+
+        let (tx, rx) = mpsc::sync_channel(4);
+        let worker = IdaWorker::new(tx);
+        let generation = DatabaseGeneration(9);
+
+        // The response senders are dropped with rx at the end of the test, so
+        // these calls resolve as worker-closed; only the emitted request matters.
+        let _ = tokio::time::timeout(
+            Duration::from_millis(50),
+            worker.dsc_load_image_for_generation("libobjc.A.dylib", Some(1), Some(generation)),
+        )
+        .await;
+        match rx.recv().expect("dsc_load_image must reach the worker") {
+            IdaRequest::DscLoadImage {
+                expected_generation,
+                ..
+            } => assert_eq!(expected_generation, Some(generation)),
+            _ => panic!("expected a DscLoadImage request"),
+        }
+
+        let _ = tokio::time::timeout(
+            Duration::from_millis(50),
+            worker.analysis_status_for_generation(Some(generation)),
+        )
+        .await;
+        match rx.recv().expect("analysis_status must reach the worker") {
+            IdaRequest::AnalysisStatus {
+                expected_generation,
+                ..
+            } => assert_eq!(expected_generation, Some(generation)),
+            _ => panic!("expected an AnalysisStatus request"),
+        }
+
+        // Foreground callers stay unbound and follow the current database.
+        let _ = tokio::time::timeout(Duration::from_millis(50), worker.analysis_status()).await;
+        match rx
+            .recv()
+            .expect("unbound analysis_status must reach the worker")
+        {
+            IdaRequest::AnalysisStatus {
+                expected_generation,
+                ..
+            } => assert_eq!(expected_generation, None),
+            _ => panic!("expected an AnalysisStatus request"),
+        }
+    }
+
     #[test]
     fn close_token_is_reused_for_same_session() {
         let worker = test_worker();
@@ -2330,6 +2453,26 @@ mod tests {
         assert_eq!(first.token, second.token);
         assert!(!first.reused);
         assert!(second.reused);
+    }
+
+    #[test]
+    fn close_tokens_are_fresh_uuid_v4_bearer_capabilities() {
+        let worker = test_worker();
+        let first = worker
+            .issue_close_token_for_session("session-a")
+            .expect("first issue should succeed");
+        worker.clear_close_token();
+        let second = worker
+            .issue_close_token_for_session("session-a")
+            .expect("second issue should succeed");
+
+        assert_ne!(first.token, second.token);
+        for token in [&first.token, &second.token] {
+            assert_eq!(token.len(), 32);
+            assert!(token.bytes().all(|byte| byte.is_ascii_hexdigit()));
+            let parsed = uuid::Uuid::parse_str(token).expect("token should parse as a UUID");
+            assert_eq!(parsed.get_version(), Some(uuid::Version::Random));
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,12 @@ use axum::Router;
 use clap::{Args, Parser, Subcommand};
 use ida_mcp::server::http_access::{HttpAccessPolicy, HttpAccessService};
 use ida_mcp::server::http_config::{
-    build_pooled_session_manager, build_session_manager, build_streamable_config, HttpServerOptions,
+    build_pooled_session_manager, build_session_manager, build_streamable_config,
+    HttpServerOptions, DEFAULT_MAX_REQUEST_BODY_MIB,
 };
 use ida_mcp::server::task::TaskRegistry;
 use ida_mcp::server::tool_filter::ToolFilter;
-use ida_mcp::server::SanitizedIdaServer;
+use ida_mcp::server::{SanitizedIdaServer, ServerRuntimeState};
 use ida_mcp::{
     disasm::generate_disasm_line,
     expand_path, ida,
@@ -157,9 +158,20 @@ struct ServeHttpArgs {
     /// Use stateless mode (POST only; no sessions)
     #[arg(long)]
     stateless: bool,
-    /// Return application/json in stateless mode instead of SSE framing.
+    /// Prefer application/json over SSE framing for sessionless responses
+    /// (--stateless mode and all MCP 2026 requests).
     #[arg(long)]
     json_response: bool,
+    /// Maximum accepted request body, in MiB. Bulk `patch` (binary as hex,
+    /// ~2x the raw size) and large `run_script` sources need headroom; the
+    /// endpoint is unauthenticated and each in-flight request can retain up
+    /// to this much, so raise it deliberately.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_MAX_REQUEST_BODY_MIB,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1024),
+    )]
+    max_request_body_mib: usize,
     /// Allowed Origin values (comma-separated). Defaults to localhost only.
     #[arg(
         long,
@@ -299,12 +311,34 @@ fn init_stdio_ida_state(allow_lumina: bool) -> anyhow::Result<ida::IdaInitState>
     }
 }
 
+/// Bounded worker shutdown. If IDA is wedged inside auto_wait() these
+/// requests sit behind it and the process can stay alive indefinitely
+/// (issue #32). After the timeout we forcibly exit so the OS reclaims
+/// IDA's mmap'd memory regardless. 124 matches GNU `timeout`'s "did its
+/// best, timed out" convention.
+async fn shutdown_worker_bounded(worker: &WorkerBackend) {
+    const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+    let close_result =
+        tokio::time::timeout(WORKER_SHUTDOWN_TIMEOUT, worker.close_for_shutdown()).await;
+    let shutdown_result = tokio::time::timeout(WORKER_SHUTDOWN_TIMEOUT, worker.shutdown()).await;
+    if close_result.is_err() || shutdown_result.is_err() {
+        warn!(
+            timeout_secs = WORKER_SHUTDOWN_TIMEOUT.as_secs(),
+            close_timed_out = close_result.is_err(),
+            shutdown_timed_out = shutdown_result.is_err(),
+            "IDA worker shutdown timed out (likely wedged in auto_wait); \
+             forcing process exit to release IDA-side memory"
+        );
+        std::process::exit(124);
+    }
+}
+
 fn cancel_background_tasks(registry: &TaskRegistry, message: &str) {
-    let cancelled = registry.cancel_all_running(message);
-    if cancelled > 0 {
+    let requested = registry.cancel_all_running(message);
+    if requested > 0 {
         info!(
-            cancelled_tasks = cancelled,
-            message, "Cancelled background tasks"
+            cancellation_requests = requested,
+            message, "Requested background task cancellation"
         );
     }
 }
@@ -346,7 +380,18 @@ fn run_server_with_mode(
             );
             let task_registry = server.task_registry().clone();
             let sanitized = SanitizedIdaServer::with_filter(server, filter_for_server);
-            let mut service = Some(sanitized.serve(stdio()).await?);
+            let mut service = match sanitized.serve(stdio()).await {
+                Ok(running) => Some(running),
+                Err(e) => {
+                    // rmcp fails the serve future without answering the client
+                    // when the first message is not a valid initialize/discover
+                    // request. Shut the IDA worker down so the process exits
+                    // instead of wedging with an unread stdin.
+                    error!(error = %e, "stdio MCP negotiation failed; shutting down IDA worker");
+                    shutdown_worker_bounded(&worker_for_shutdown).await;
+                    return Err(anyhow::anyhow!("stdio MCP negotiation failed: {e}"));
+                }
+            };
             let shutdown_notify = Arc::new(Notify::new());
             let shutdown_signal = shutdown_notify.clone();
 
@@ -400,32 +445,7 @@ fn run_server_with_mode(
                 }
             }
             info!("MCP server shutting down");
-            // Bounded worker shutdown. If IDA is wedged inside auto_wait()
-            // these requests sit behind it and the process can stay alive
-            // indefinitely (issue #32). After the timeout we forcibly exit
-            // so the OS reclaims IDA's mmap'd memory regardless. 124
-            // matches GNU `timeout`'s "did its best, timed out" convention.
-            const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
-            let close_result = tokio::time::timeout(
-                WORKER_SHUTDOWN_TIMEOUT,
-                worker_for_shutdown.close_for_shutdown(),
-            )
-            .await;
-            let shutdown_result = tokio::time::timeout(
-                WORKER_SHUTDOWN_TIMEOUT,
-                worker_for_shutdown.shutdown(),
-            )
-            .await;
-            if close_result.is_err() || shutdown_result.is_err() {
-                warn!(
-                    timeout_secs = WORKER_SHUTDOWN_TIMEOUT.as_secs(),
-                    close_timed_out = close_result.is_err(),
-                    shutdown_timed_out = shutdown_result.is_err(),
-                    "IDA worker shutdown timed out (likely wedged in auto_wait); \
-                     forcing process exit to release IDA-side memory"
-                );
-                std::process::exit(124);
-            }
+            shutdown_worker_bounded(&worker_for_shutdown).await;
             Ok::<_, anyhow::Error>(())
         })
     });
@@ -436,10 +456,18 @@ fn run_server_with_mode(
     info!("IDA worker loop finished");
 
     // Wait for server thread to finish
+    // Propagate server-thread failures (e.g. stdio negotiation errors) into
+    // the process exit status so supervisors can tell them from clean shutdown.
     match server_handle.join() {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => error!("Server thread failed: {e}"),
-        Err(e) => error!("Server thread panicked: {:?}", e),
+        Ok(Err(e)) => {
+            error!("Server thread failed: {e}");
+            return Err(e);
+        }
+        Err(e) => {
+            error!("Server thread panicked: {:?}", e);
+            return Err(anyhow::anyhow!("server thread panicked: {e:?}"));
+        }
     }
 
     info!("Server stopped");
@@ -454,7 +482,7 @@ fn run_server_http(
 ) -> anyhow::Result<()> {
     info!("Starting IDA MCP Server (streamable HTTP mode)");
     if args.json_response && !args.stateless {
-        info!("--json-response is ignored unless --stateless is also set");
+        info!("--json-response applies to sessionless dispatch (MCP 2026 requests); legacy sessions keep SSE framing for streams");
     }
     if args.max_workers == 0 {
         return Err(anyhow::anyhow!("--max-workers must be at least 1"));
@@ -507,17 +535,17 @@ fn run_server_http(
     let worker_for_factory = backend.clone();
     let worker_for_shutdown = backend.clone();
     let filter_for_factory = filter.clone();
-    let server_handle = thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_multi_thread()
+    let runtime_state = if args.stateless {
+        ServerRuntimeState::new_stateless_http()
+    } else {
+        ServerRuntimeState::new()
+    };
+    let worker_for_startup_failure = backend.clone();
+    let server_handle = thread::spawn(move || -> anyhow::Result<()> {
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                error!("Failed to create tokio runtime: {e}");
-                return;
-            }
-        };
+            .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
 
         let result = rt.block_on(async move {
             let listener = tokio::net::TcpListener::bind(bind_addr)
@@ -541,16 +569,18 @@ fn run_server_http(
                     sse_keep_alive_secs: args.sse_keep_alive_secs,
                     stateless: args.stateless,
                     json_response: args.json_response,
+                    max_request_body_mib: args.max_request_body_mib,
                 },
                 cancel.clone(),
             );
 
             let service = StreamableHttpService::new(
                 move || {
-                    let inner = IdaMcpServer::with_filter(
+                    let inner = IdaMcpServer::with_filter_and_state(
                         worker_for_factory.clone(),
                         ServerMode::Http,
                         filter_for_factory.clone(),
+                        runtime_state.clone(),
                     );
                     Ok(SanitizedIdaServer::with_filter(
                         inner,
@@ -586,17 +616,32 @@ fn run_server_http(
                 .map_err(|e| anyhow::anyhow!("serve failed: {e}"))?;
             Ok::<_, anyhow::Error>(())
         });
-        if let Err(err) = result {
+        if let Err(err) = &result {
             error!("HTTP server error: {err}");
+            // The main thread is parked in run_ida_loop and nothing else will
+            // send it a shutdown request, so a failed startup would otherwise
+            // wedge the process alive holding an IDA license with no listener.
+            rt.block_on(shutdown_worker_bounded(&worker_for_startup_failure));
         }
+        result
     });
 
     info!("Starting IDA worker loop");
     ida::run_ida_loop(rx, init_state);
     info!("IDA worker loop finished");
 
-    if let Err(e) = server_handle.join() {
-        error!("Server thread panicked: {:?}", e);
+    // Propagate startup/serve failures into the exit status so supervisors can
+    // tell "could not start" from a clean shutdown.
+    match server_handle.join() {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            error!("Server thread failed: {e}");
+            return Err(e);
+        }
+        Err(e) => {
+            error!("Server thread panicked: {:?}", e);
+            return Err(anyhow::anyhow!("server thread panicked: {e:?}"));
+        }
     }
 
     info!("Server stopped");
@@ -615,17 +660,11 @@ fn run_server_http_pooled(
         min_workers = args.min_workers,
         "Starting pooled HTTP router; parent will not initialize IDA"
     );
-    let server_handle = thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_multi_thread()
+    let server_handle = thread::spawn(move || -> anyhow::Result<()> {
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                error!("Failed to create tokio runtime: {e}");
-                return;
-            }
-        };
+            .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {e}"))?;
 
         let result = rt.block_on(async move {
             let listener = tokio::net::TcpListener::bind(bind_addr)
@@ -673,6 +712,7 @@ fn run_server_http_pooled(
                     sse_keep_alive_secs: args.sse_keep_alive_secs,
                     stateless: args.stateless,
                     json_response: args.json_response,
+                    max_request_body_mib: args.max_request_body_mib,
                 },
                 cancel.clone(),
             );
@@ -725,13 +765,24 @@ fn run_server_http_pooled(
             pool.shutdown_all().await;
             Ok::<_, anyhow::Error>(())
         });
-        if let Err(err) = result {
-            error!("HTTP server error: {err}");
+        if let Err(err) = &result {
+            error!("Pooled HTTP server error: {err}");
         }
+        result
     });
 
-    if let Err(e) = server_handle.join() {
-        error!("Server thread panicked: {:?}", e);
+    // Same contract as single-worker HTTP and stdio: a server that never
+    // started must not report success.
+    match server_handle.join() {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            error!("Server thread failed: {e}");
+            return Err(e);
+        }
+        Err(e) => {
+            error!("Server thread panicked: {:?}", e);
+            return Err(anyhow::anyhow!("server thread panicked: {e:?}"));
+        }
     }
 
     info!("Pooled HTTP server stopped");

--- a/src/server/http_config.rs
+++ b/src/server/http_config.rs
@@ -23,6 +23,8 @@ pub struct HttpServerOptions {
     pub stateless: bool,
     /// Return `application/json` instead of SSE in stateless mode.
     pub json_response: bool,
+    /// Request-body cap in MiB (see [`DEFAULT_MAX_REQUEST_BODY_MIB`]).
+    pub max_request_body_mib: usize,
 }
 
 fn session_manager_with_keep_alive(session_keep_alive_secs: u64) -> LocalSessionManager {
@@ -136,7 +138,7 @@ impl SessionManager for PooledSessionManager {
         id: &SessionId,
         last_event_id: String,
     ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
-        // rmcp 1.7 local::EventId formats request-scoped streams as
+        // rmcp local::EventId formats request-scoped streams as
         // "<index>/<request_id>" and standalone streams as "<index>".
         let close_on_drop = !last_event_id.contains('/');
         let stream = self.inner.resume(id, last_event_id).await?;
@@ -340,6 +342,20 @@ impl<S> Drop for TrackedSessionStream<S> {
     }
 }
 
+const BYTES_PER_MIB: usize = 1024 * 1024;
+
+/// Default request-body cap for HTTP transports, in MiB.
+///
+/// rmcp 3 introduced a 4 MiB default that is too small for this server's bulk
+/// tools: `patch` sends binary as hex (2.0x the raw size) and `run_script`
+/// sends whole IDAPython sources. The HTTP endpoint has no authentication —
+/// only Origin/Host checks — and rmcp grows a per-request buffer up to this
+/// cap before parsing, so concurrent requests each retain up to this much.
+/// 16 MiB covers a ~1.4 MiB binary patch with wide headroom while keeping that
+/// unauthenticated retention surface bounded. Operators who need more (or
+/// less) set `--max-request-body-mib`.
+pub const DEFAULT_MAX_REQUEST_BODY_MIB: usize = 16;
+
 pub fn build_streamable_config(
     opts: HttpServerOptions,
     cancel: CancellationToken,
@@ -351,8 +367,14 @@ pub fn build_streamable_config(
             Some(Duration::from_secs(opts.sse_keep_alive_secs))
         })
         .with_sse_retry(None)
-        .with_stateful_mode(!opts.stateless)
-        .with_json_response(opts.json_response && opts.stateless)
+        .with_legacy_session_mode(!opts.stateless)
+        // Sessionless dispatch is no longer tied to --stateless: MCP 2026
+        // requests always take it, so the flag applies there too instead of
+        // being silently dropped without --stateless.
+        .with_json_response(opts.json_response)
+        // rmcp defaults to a 4 MiB body cap; large patch/run_script payloads
+        // are legitimate here, so raise it to the operator-selected bound.
+        .with_max_request_body_bytes(opts.max_request_body_mib.saturating_mul(BYTES_PER_MIB))
         .with_cancellation_token(cancel)
         // Host validation is handled by HttpAccessService so the CLI can apply
         // bind-aware LAN rules and return actionable 403 messages.
@@ -375,6 +397,7 @@ mod tests {
             sse_keep_alive_secs: 15,
             stateless: false,
             json_response: false,
+            max_request_body_mib: crate::server::http_config::DEFAULT_MAX_REQUEST_BODY_MIB,
         }
     }
 
@@ -388,16 +411,56 @@ mod tests {
     }
 
     #[test]
-    fn json_response_only_enabled_in_stateless_mode() {
+    fn json_response_applies_to_all_sessionless_dispatch() {
         let mut opts = opts();
         opts.json_response = true;
 
+        // MCP 2026 requests are dispatched sessionless even with legacy
+        // sessions enabled, so the flag must not depend on --stateless.
         let stateful = build_streamable_config(opts.clone(), CancellationToken::new());
-        assert!(!stateful.json_response);
+        assert!(stateful.json_response);
 
         opts.stateless = true;
         let stateless = build_streamable_config(opts, CancellationToken::new());
         assert!(stateless.json_response);
+    }
+
+    #[test]
+    fn request_body_cap_default_accepts_bulk_tools_without_the_64_mib_surface() {
+        let config = build_streamable_config(opts(), CancellationToken::new());
+        assert_eq!(config.max_request_body_bytes, 16 * 1024 * 1024);
+        // Large enough for bulk patch/run_script payloads rmcp's 4 MiB
+        // default rejects, small enough that concurrent unauthenticated
+        // requests cannot each retain the previous 64 MiB.
+        assert!(config.max_request_body_bytes > 4 * 1024 * 1024);
+        assert!(config.max_request_body_bytes < 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn request_body_cap_follows_the_operator_value() {
+        let mut opts = opts();
+        opts.max_request_body_mib = 1;
+        let config = build_streamable_config(opts, CancellationToken::new());
+        assert_eq!(config.max_request_body_bytes, 1024 * 1024);
+    }
+
+    #[test]
+    fn request_body_cap_saturates_instead_of_overflowing() {
+        let mut opts = opts();
+        opts.max_request_body_mib = usize::MAX;
+        let config = build_streamable_config(opts, CancellationToken::new());
+        assert_eq!(config.max_request_body_bytes, usize::MAX);
+    }
+
+    #[test]
+    fn stateless_option_disables_legacy_sessions() {
+        let stateful = build_streamable_config(opts(), CancellationToken::new());
+        assert!(stateful.legacy_session_mode);
+
+        let mut stateless_opts = opts();
+        stateless_opts.stateless = true;
+        let stateless = build_streamable_config(stateless_opts, CancellationToken::new());
+        assert!(!stateless.legacy_session_mode);
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,6 +12,7 @@ pub use requests::*;
 use crate::error::ToolError;
 use crate::ida::observability::{ProgressReceiver, ProgressSender};
 use crate::ida::pool::CHILD_TIMEOUT_GRACE_SECS;
+use crate::ida::types::{ConditionalCloseResult, DatabaseGeneration};
 use crate::ida::worker::{
     CloseAuthorization, CloseTokenGrant, IdaWorker, WorkerBackend, MAX_TIMEOUT_SECS,
 };
@@ -20,7 +21,11 @@ use crate::server::operation::{
 };
 use crate::tool_registry::{self, ToolCategory};
 use rmcp::{
-    handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
+    handler::server::{
+        router::tool::ToolRouter,
+        tool::{InputResponses as ToolInputResponses, RequestState, ToolCallContext},
+        wrapper::Parameters,
+    },
     model::{
         CallToolResult, ContentBlock as Content, ServerCapabilities, ServerInfo, Tool,
         ToolAnnotations,
@@ -29,14 +34,66 @@ use rmcp::{
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
 use serde_json::{json, Map, Value};
+use std::borrow::Cow;
 use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use tracing::{debug, info, instrument, warn};
 
 struct SessionLifetime {
     cancel: tokio_util::sync::CancellationToken,
+}
+
+/// State that must survive across handler instances created for stateless MCP
+/// requests. Long-lived transports use one value per handler; single-worker
+/// HTTP shares one value across legacy sessions and modern sessionless requests
+/// because they all operate on the same IDA context.
+#[derive(Clone)]
+pub struct ServerRuntimeState {
+    task_registry: task::TaskRegistry,
+    operation_registry: OperationRegistry,
+    operation_nonce: Arc<AtomicU64>,
+    /// Parent lifetime for background tasks spawned by sessionless MCP 2026
+    /// requests, whose handlers drop as soon as the response is sent. Cancelled
+    /// only when the runtime state itself drops (process/transport shutdown).
+    runtime_lifetime: Arc<SessionLifetime>,
+    request_state_codec: rmcp::model::RequestStateCodec,
+    /// True when the HTTP transport runs with `--stateless`: rmcp then builds
+    /// a fresh handler per request even for legacy protocol versions, so every
+    /// request must use the shared runtime task owner and lifetime — otherwise
+    /// a legacy client's background task would be cancelled when its handler
+    /// drops and owned by a session identity that never recurs.
+    stateless_http: bool,
+}
+
+impl Default for ServerRuntimeState {
+    fn default() -> Self {
+        let signing_key = format!("{}{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+        Self {
+            task_registry: task::TaskRegistry::new(),
+            operation_registry: OperationRegistry::new(),
+            operation_nonce: Arc::new(AtomicU64::new(0)),
+            runtime_lifetime: Arc::new(SessionLifetime::new()),
+            request_state_codec: rmcp::model::RequestStateCodec::new(signing_key.into_bytes()),
+            stateless_http: false,
+        }
+    }
+}
+
+impl ServerRuntimeState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Runtime state for an HTTP transport started with `--stateless` (see
+    /// [`Self::stateless_http`]).
+    pub fn new_stateless_http() -> Self {
+        Self {
+            stateless_http: true,
+            ..Self::default()
+        }
+    }
 }
 
 impl SessionLifetime {
@@ -66,10 +123,24 @@ pub struct IdaMcpServer {
     task_registry: task::TaskRegistry,
     operation_registry: OperationRegistry,
     operation_nonce: Arc<AtomicU64>,
+    /// Shared runtime lifetime (see [`ServerRuntimeState::runtime_lifetime`]).
+    runtime_lifetime: Arc<SessionLifetime>,
+    /// Per-handler lifetime. rmcp keeps a legacy session's handler alive for
+    /// the whole session and drops it on session close, so background tasks
+    /// parented here are cancelled when their legacy session ends. Sessionless
+    /// MCP 2026 handlers drop per request, so their background tasks must use
+    /// `runtime_lifetime` instead (see [`Self::background_lifetime`]).
     session_lifetime: Arc<SessionLifetime>,
-    /// Unique ID for this server instance. Changes on restart, making silent
-    /// auto-restarts (e.g. after a Hex-Rays C++ crash) visible to agents.
+    request_state_codec: rmcp::model::RequestStateCodec,
+    /// Unique ID for this handler context. It is stable for a legacy session,
+    /// while sessionless MCP 2026 HTTP creates a fresh value per request. It is
+    /// also the ownership identity used by the legacy HTTP close-token path.
     session_id: String,
+    /// Stable task owner for requests served through this handler. Sessionless
+    /// MCP 2026 requests instead use the shared runtime owner.
+    session_task_owner: task::TaskOwner,
+    /// See [`ServerRuntimeState::stateless_http`].
+    stateless_http: bool,
     /// Server-side tool filter (applied to tools/list, tools/call, and
     /// surfaced via tool_catalog / tool_help).
     filter: Arc<tool_filter::ToolFilter>,
@@ -95,13 +166,6 @@ where
         Self { call_router }
     }
 
-    async fn call(
-        &self,
-        context: ToolCallContext<'_, S>,
-    ) -> Result<CallToolResult, rmcp::ErrorData> {
-        self.call_router.call(context).await
-    }
-
     fn list_all(&self) -> Vec<Tool> {
         let mut tools = Vec::new();
         for info in tool_registry::all_tools() {
@@ -114,6 +178,69 @@ where
 
     fn get(&self, name: &str) -> Option<&Tool> {
         self.call_router.map.get(name).map(|route| &route.attr)
+    }
+}
+
+/// Tools whose handlers consume MRTR `requestState`/`inputResponses`. Other
+/// tools must reject those fields instead of silently executing a fresh call.
+const MRTR_AWARE_TOOLS: &[&str] = &["open_idb"];
+
+/// True when a request carries the complete MCP 2026 inline-metadata key set.
+/// rmcp routes such requests through the sessionless per-request path
+/// regardless of the protocol version the metadata declares (`is_legacy_request`,
+/// tower.rs), so this is the authoritative "which handler lifetime am I running
+/// under" predicate on HTTP transports.
+fn is_sessionless_request_meta(meta: &rmcp::model::RequestMetaObject) -> bool {
+    meta.missing_required_keys(&ProtocolVersion::V_2026_07_28)
+        .is_empty()
+}
+
+impl ToolMux<IdaMcpServer> {
+    async fn call(
+        &self,
+        context: ToolCallContext<'_, IdaMcpServer>,
+    ) -> Result<CallToolResponse, rmcp::ErrorData> {
+        // rmcp routes any request carrying the complete 2026 inline-metadata
+        // key set through the sessionless path even when it declares a legacy
+        // protocol version. Pooled workers bind their IDA lease to a legacy
+        // HTTP session, so a sessionless tool call would mint (and leak) a
+        // fresh worker lease per request. Reject it before it reaches the
+        // worker pool; the version allowlist alone cannot catch this case.
+        if context.service.worker.is_pooled()
+            && is_sessionless_request_meta(&context.request_context().meta)
+        {
+            return Err(McpError::invalid_params(
+                "pooled HTTP (--max-workers > 1) requires the legacy initialize lifecycle; \
+                 sessionless inline request metadata is not supported here",
+                None,
+            ));
+        }
+        if !MRTR_AWARE_TOOLS.contains(&context.name())
+            && (context.request_state.is_some() || context.input_responses.is_some())
+        {
+            return Err(McpError::invalid_params(
+                format!(
+                    "tool '{}' does not accept requestState/inputResponses",
+                    context.name()
+                ),
+                None,
+            ));
+        }
+        // SEP-2663 task handles exist from MCP 2026-07-28; older peers cannot
+        // parse a `resultType: "task"` response even if they declared the
+        // tasks extension capability.
+        let should_materialize_task = context.name() == "open_dsc"
+            && context
+                .request_context()
+                .protocol_version()
+                .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
+            && context
+                .request_context()
+                .client_capabilities()
+                .is_some_and(|capabilities| capabilities.supports_tasks());
+        let task_registry = context.service.task_registry.clone();
+        let response = self.call_router.call(context).await?;
+        materialize_task_response(&task_registry, should_materialize_task, response)
     }
 }
 
@@ -151,10 +278,14 @@ enum DscOpenPlan {
 }
 
 fn dsc_open_plan(sdk_version: (i32, i32), i64_exists: bool) -> DscOpenPlan {
-    if sdk_version >= (9, 4) {
-        DscOpenPlan::BackgroundDirectRawDsc
-    } else if i64_exists {
+    // An existing database wins on every SDK: reopening it preserves prior
+    // analysis (renames, comments, loaded modules) and skips the load. On 9.4
+    // that database is the deterministic direct-path cache or a legacy
+    // sibling; pre-9.4 it is the sibling idat produced.
+    if i64_exists {
         DscOpenPlan::DirectExistingI64
+    } else if sdk_version >= (9, 4) {
+        DscOpenPlan::BackgroundDirectRawDsc
     } else {
         DscOpenPlan::LegacyIdatBackground
     }
@@ -176,18 +307,28 @@ fn sanitize_temp_component(value: &str) -> String {
     }
 }
 
-fn direct_dsc_temp_i64_path(dsc_path: &std::path::Path) -> Result<std::path::PathBuf, ToolError> {
-    let name = dsc_path
+/// Deterministic per-DSC database location for the IDA 9.4 direct open path.
+///
+/// DSCs commonly sit on read-only mounts, so the generated database cannot
+/// reliably live next to them the way the legacy idat path's sibling `.i64`
+/// does. Deriving the name from the absolute DSC path — never pid or time —
+/// means every `open_dsc` of the same cache resolves to one file: repeat opens
+/// reuse the analyzed database (with any renames/comments) instead of leaking
+/// a fresh multi-GB orphan per call.
+fn direct_dsc_cache_i64_path(dsc_path: &std::path::Path) -> std::path::PathBuf {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let absolute = dsc_path
+        .canonicalize()
+        .unwrap_or_else(|_| dsc_path.to_path_buf());
+    let name = absolute
         .file_name()
         .and_then(|name| name.to_str())
         .map(sanitize_temp_component)
         .unwrap_or_else(|| "dsc".to_string());
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|err| ToolError::InvalidParams(format!("system clock error: {err}")))?
-        .as_nanos();
-    let pid = std::process::id();
-    Ok(std::env::temp_dir().join(format!("ida-mcp-dsc-{pid}-{now}-{name}.i64")))
+    let mut hasher = DefaultHasher::new();
+    absolute.hash(&mut hasher);
+    let hash = hasher.finish();
+    std::env::temp_dir().join(format!("ida-mcp-dsc-{name}-{hash:016x}.i64"))
 }
 
 impl TemporaryFileCleanup {
@@ -229,6 +370,7 @@ const OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES: u64 = 50 * 1024 * 1024;
 /// Bound the MCP elicitation prompt separately from IDA work. If the client
 /// leaves the prompt unanswered, default to background analysis.
 const OPEN_IDB_ELICITATION_TIMEOUT_SECS: u64 = 30;
+const OPEN_IDB_REQUEST_STATE_TTL_SECS: u64 = 10 * 60;
 /// Give foreground operations a short window to observe cancellation and clean
 /// up owned resources before the MCP timeout/cancel response is returned.
 const FOREGROUND_CANCEL_CLEANUP_TIMEOUT_SECS: u64 = 6;
@@ -249,6 +391,11 @@ enum ForegroundOperationError {
     Cancelled {
         snapshot: OperationSnapshot,
     },
+}
+
+enum OpenIdbBackgroundDecision {
+    Ready(bool),
+    InputRequired(InputRequiredResult),
 }
 
 fn timeout_with_child_grace(timeout_secs: Option<u64>, default_timeout_secs: u64) -> u64 {
@@ -279,25 +426,73 @@ impl IdaMcpServer {
         mode: ServerMode,
         filter: Arc<tool_filter::ToolFilter>,
     ) -> Self {
+        Self::with_filter_and_state(worker, mode, filter, ServerRuntimeState::new())
+    }
+
+    pub fn with_filter_and_state(
+        worker: WorkerBackend,
+        mode: ServerMode,
+        filter: Arc<tool_filter::ToolFilter>,
+        state: ServerRuntimeState,
+    ) -> Self {
         let session_id = uuid::Uuid::new_v4().to_string();
-        info!(
+        let session_task_owner = task::TaskOwner::Session(Arc::from(session_id.as_str()));
+        // debug!: sessionless MCP 2026 HTTP constructs a handler per request,
+        // so this is per-request noise there, not a once-per-server event.
+        debug!(
             session_id = %session_id,
             tool_filter_active = filter.is_active(),
             enabled_tools = filter.enabled_count(),
-            "Creating IDA MCP server"
+            "Creating IDA MCP server handler"
         );
         let call_router = Self::tool_router();
         Self {
             worker,
             tool_mux: ToolMux::new(call_router),
             mode,
-            task_registry: task::TaskRegistry::new(),
-            operation_registry: OperationRegistry::new(),
-            operation_nonce: Arc::new(AtomicU64::new(0)),
+            task_registry: state.task_registry,
+            operation_registry: state.operation_registry,
+            operation_nonce: state.operation_nonce,
+            runtime_lifetime: state.runtime_lifetime,
             session_lifetime: Arc::new(SessionLifetime::new()),
+            request_state_codec: state.request_state_codec,
             session_id,
+            session_task_owner,
+            stateless_http: state.stateless_http,
             filter,
         }
+    }
+
+    /// Parent lifetime for background tasks spawned while serving `meta`'s
+    /// request. Only HTTP uses metadata completeness to select rmcp's
+    /// per-request sessionless route. Stdio always has one connection-scoped
+    /// handler, even when an individual request carries the full key set.
+    fn background_lifetime(&self, meta: &rmcp::model::RequestMetaObject) -> &SessionLifetime {
+        if self.is_sessionless_http_request(meta) {
+            &self.runtime_lifetime
+        } else {
+            &self.session_lifetime
+        }
+    }
+
+    /// Owner identity for task admission and client-facing task operations.
+    /// Sessionless HTTP requests share one owner because MCP 2026 supplies no
+    /// stable session identifier across requests. Stdio remains bound to its
+    /// connection-scoped handler regardless of per-request metadata shape.
+    fn task_owner(&self, meta: &rmcp::model::RequestMetaObject) -> task::TaskOwner {
+        if self.is_sessionless_http_request(meta) {
+            task::TaskOwner::Runtime
+        } else {
+            self.session_task_owner.clone()
+        }
+    }
+
+    fn is_sessionless_http_request(&self, meta: &rmcp::model::RequestMetaObject) -> bool {
+        // Under `--stateless` every HTTP request is per-handler regardless of
+        // protocol version, so legacy requests must also use the runtime
+        // owner and lifetime (see `ServerRuntimeState::stateless_http`).
+        matches!(self.mode, ServerMode::Http)
+            && (self.stateless_http || is_sessionless_request_meta(meta))
     }
 
     pub fn filter(&self) -> &Arc<tool_filter::ToolFilter> {
@@ -899,16 +1094,20 @@ impl IdaMcpServer {
 
     fn start_dsc_background(
         &self,
+        owner: &task::TaskOwner,
         dedup_key: String,
         initial_message: &str,
         ctx: DscBackgroundCtx,
+        cancel_token: tokio_util::sync::CancellationToken,
     ) -> Result<CallToolResult, McpError> {
-        let task_id = match self
-            .task_registry
-            .create_keyed("dsc", &dedup_key, initial_message)
-        {
+        let task_id = match self.task_registry.create_keyed(
+            owner,
+            "dsc",
+            &dedup_key,
+            initial_message,
+        ) {
             Ok(id) => id,
-            Err(existing_id) => {
+            Err(task::TaskCreateError::AlreadyRunning(existing_id)) => {
                 return Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&json!({
                         "status": "already_running",
@@ -918,6 +1117,7 @@ impl IdaMcpServer {
                     .unwrap_or_default(),
                 )]));
             }
+            Err(error) => return Ok(task_create_error_to_tool_error(error).to_tool_result()),
         };
 
         let backend = match &ctx.open {
@@ -925,7 +1125,6 @@ impl IdaMcpServer {
             DscBackgroundOpen::LegacyIdat { .. } => "idat",
         };
         info!(
-            task_id = %task_id,
             module = %ctx.module,
             backend,
             "Spawning background DSC loading"
@@ -935,13 +1134,11 @@ impl IdaMcpServer {
         let worker = self.worker.clone();
         let mode = self.mode;
         let tid = task_id.clone();
-        let cancel_token = self.session_lifetime.child_token();
         let task_cancel_token = cancel_token.clone();
-        let handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             Self::run_dsc_background(tid, registry, worker, mode, ctx, task_cancel_token).await;
         });
-        self.task_registry
-            .set_handle_with_cancel_token(&task_id, handle, cancel_token);
+        self.task_registry.set_cancel_token(&task_id, cancel_token);
 
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&json!({
@@ -964,9 +1161,13 @@ impl IdaMcpServer {
         info!(path = %open_path.display(), file_type, "Opening DSC directly through idalib");
 
         let open_path_str = open_path.display().to_string();
+        // Bind the image loads below to the database this call opened. The IDA
+        // worker serves every session, so another session's close_idb between
+        // the open and a load would otherwise redirect the load — which
+        // mutates the database — into whatever database is current.
         let open_result = self
             .worker
-            .open(
+            .open_observed_with_generation(
                 &open_path_str,
                 false,
                 None,
@@ -976,17 +1177,25 @@ impl IdaMcpServer {
                 file_type.map(str::to_string),
                 false,
                 Vec::new(),
+                None,
+                None,
+                None,
+                None,
             )
             .await;
 
-        let db_info = match open_result {
-            Ok(info) => info,
+        let (db_info, generation) = match open_result {
+            Ok(opened) => (opened.info, Some(opened.generation)),
             Err(e) => return Ok(e.to_tool_result()),
         };
 
         let mut loaded_images = Vec::with_capacity(frameworks.len() + 1);
         let mut dsc_warning = None;
-        match self.worker.dsc_load_image(module, Some(600)).await {
+        match self
+            .worker
+            .dsc_load_image_for_generation(module, Some(600), generation)
+            .await
+        {
             Ok(image) => loaded_images.push(image),
             Err(ToolError::NotSupported(message)) if file_type.is_none() => {
                 dsc_warning = Some(format!(
@@ -997,14 +1206,18 @@ impl IdaMcpServer {
         }
         if dsc_warning.is_none() {
             for framework in frameworks {
-                match self.worker.dsc_load_image(framework, Some(600)).await {
+                match self
+                    .worker
+                    .dsc_load_image_for_generation(framework, Some(600), generation)
+                    .await
+                {
                     Ok(image) => loaded_images.push(image),
                     Err(e) => return Ok(e.to_tool_result()),
                 }
             }
         }
 
-        let analysis_status = match self.worker.analysis_status().await {
+        let analysis_status = match self.worker.analysis_status_for_generation(generation).await {
             Ok(status) => Some(status),
             Err(err) => {
                 warn!(module = %module, error = %err, "failed to fetch analysis_status after open_dsc");
@@ -1060,20 +1273,78 @@ impl IdaMcpServer {
         )]))
     }
 
-    async fn fail_dsc_background_after_open(
+    fn complete_background_tool_error(
+        task_id: &str,
+        registry: &task::TaskRegistry,
+        error: &ToolError,
+        cancel_token: &tokio_util::sync::CancellationToken,
+        cancel_message: &str,
+    ) -> task::TaskSettlement {
+        registry.complete_with_cancel_token(
+            task_id,
+            call_tool_result_to_value(&error.to_tool_result()),
+            cancel_token,
+            cancel_message,
+        )
+    }
+
+    async fn finish_dsc_tool_error_after_open(
         task_id: &str,
         registry: &task::TaskRegistry,
         worker: &WorkerBackend,
-        message: String,
+        generation: DatabaseGeneration,
+        error: ToolError,
+        cancel_token: &tokio_util::sync::CancellationToken,
     ) {
-        if let Err(close_err) = worker.close().await {
-            warn!(
-                task_id,
-                error = %close_err,
-                "failed to close database after background DSC task failure"
-            );
+        match worker.close_if_generation(generation).await {
+            Ok(ConditionalCloseResult::Closed | ConditionalCloseResult::NotCurrent) => {
+                Self::complete_background_tool_error(
+                    task_id,
+                    registry,
+                    &error,
+                    cancel_token,
+                    "Cancelled after the failed DSC operation settled",
+                );
+            }
+            Err(close_error) => {
+                let message = format!(
+                    "{error}; cleanup failed for database generation {}: {close_error}",
+                    generation.0
+                );
+                warn!(error = %message, "background DSC failure cleanup did not settle safely");
+                registry.fail_after_cleanup_error(task_id, &message);
+            }
         }
-        registry.fail(task_id, &message);
+    }
+
+    async fn finish_dsc_cancellation_after_open(
+        task_id: &str,
+        registry: &task::TaskRegistry,
+        worker: &WorkerBackend,
+        generation: DatabaseGeneration,
+    ) {
+        match worker.close_if_generation(generation).await {
+            Ok(ConditionalCloseResult::Closed) => {
+                registry.finish_cancelled(
+                    task_id,
+                    "Cancelled after the active DSC operation settled and its database closed",
+                );
+            }
+            Ok(ConditionalCloseResult::NotCurrent) => {
+                registry.finish_cancelled(
+                    task_id,
+                    "Cancelled after the active DSC operation settled; its database generation was already replaced",
+                );
+            }
+            Err(error) => {
+                let message = format!(
+                    "Cancellation cleanup failed for database generation {}: {error}",
+                    generation.0
+                );
+                warn!(error = %error, "failed to close cancelled DSC database generation");
+                registry.fail_after_cleanup_error(task_id, &message);
+            }
+        }
     }
 
     /// Background task: open a DSC through the selected backend, then load images.
@@ -1100,7 +1371,6 @@ impl IdaMcpServer {
         let (open_path, idb_out, auto_analyse, load_images_with_dscu) = match open {
             DscBackgroundOpen::DirectRawDsc { open_path, idb_out } => {
                 info!(
-                    task_id = %task_id,
                     path = %open_path.display(),
                     idb_out = %idb_out.display(),
                     "Background: opening raw DSC through idalib"
@@ -1118,63 +1388,77 @@ impl IdaMcpServer {
                 let mut script_cleanup = TemporaryFileCleanup::new(script_path);
 
                 // Phase 1: run idat subprocess
-                info!(task_id = %task_id, "Background: running idat");
+                info!("Background: running idat");
                 registry.update_message(&task_id, "Running idat to create .i64...");
 
-                let idat_bin = idat;
-                let module_env = module.clone();
-                let out_i64_clone = out_i64.clone();
-                let log_path_clone = log_path.clone();
+                let mut cmd = tokio::process::Command::new(&idat);
+                cmd.args(&idat_args);
+                // Remove env vars that cause license conflicts when our
+                // process links idalib and also spawns idat.
+                cmd.env_remove("IDADIR");
+                cmd.env_remove("DYLD_LIBRARY_PATH");
+                cmd.env("IDA_DYLD_CACHE_MODULE", &module);
+                // idat's diagnostics go to stderr and the -L log file; stdout
+                // is never read, and leaving it on an undrained pipe could
+                // block idat once the buffer fills.
+                cmd.stdout(std::process::Stdio::null());
+                cmd.stderr(std::process::Stdio::piped());
 
-                let spawn_task = tokio::task::spawn_blocking(move || {
-                    let mut cmd = std::process::Command::new(&idat_bin);
-                    cmd.args(&idat_args);
-                    // Remove env vars that cause license conflicts when our
-                    // process links idalib and also spawns idat.
-                    cmd.env_remove("IDADIR");
-                    cmd.env_remove("DYLD_LIBRARY_PATH");
-                    cmd.env("IDA_DYLD_CACHE_MODULE", &module_env);
-                    cmd.stdout(std::process::Stdio::piped());
-                    cmd.stderr(std::process::Stdio::piped());
-
-                    let output = cmd.output();
-
-                    match output {
-                        Ok(out) => {
-                            let code = out.status.code().unwrap_or(-1);
-                            let stderr = String::from_utf8_lossy(&out.stderr);
-                            (code, stderr.to_string(), out_i64_clone, log_path_clone)
-                        }
-                        Err(e) => (
-                            -1,
-                            format!("Failed to spawn idat: {e}"),
-                            out_i64_clone,
-                            log_path_clone,
-                        ),
+                let (exit_code, stderr) = match cmd.spawn() {
+                    Ok(mut child) => {
+                        let mut stderr_pipe = child.stderr.take();
+                        let mut stderr_buf = Vec::new();
+                        let status = {
+                            let wait = async {
+                                if let Some(pipe) = stderr_pipe.as_mut() {
+                                    use tokio::io::AsyncReadExt as _;
+                                    let _ = pipe.read_to_end(&mut stderr_buf).await;
+                                }
+                                child.wait().await
+                            };
+                            tokio::pin!(wait);
+                            tokio::select! {
+                                status = &mut wait => Some(status),
+                                () = cancel_token.cancelled() => None,
+                            }
+                        };
+                        let Some(status) = status else {
+                            // Kill idat and reap it before publishing the
+                            // terminal state, so no IDA work survives a task
+                            // that reports itself cancelled. A killed idat can
+                            // leave partial database files that dsc_open_plan
+                            // would reuse on the next call — remove them.
+                            stop_idat_and_remove_partial_outputs(&mut child, &out_i64).await;
+                            registry.finish_cancelled(
+                                &task_id,
+                                "Cancelled; the idat subprocess was killed and its partial output removed",
+                            );
+                            return;
+                        };
+                        let exit_code = match status {
+                            Ok(status) => status.code().unwrap_or(-1),
+                            Err(e) => {
+                                stop_idat_and_remove_partial_outputs(&mut child, &out_i64).await;
+                                registry.fail(&task_id, &format!("failed to wait for idat: {e}"));
+                                return;
+                            }
+                        };
+                        (exit_code, String::from_utf8_lossy(&stderr_buf).into_owned())
                     }
-                });
-
-                let spawn_result = tokio::select! {
-                    result = spawn_task => result,
-                    _ = cancel_token.cancelled() => {
-                        registry.finish_cancelled(&task_id, "Cancelled by session shutdown");
-                        return;
-                    }
+                    Err(e) => (-1, format!("Failed to spawn idat: {e}")),
                 };
 
-                let (exit_code, stderr, out_path, log_out) = match spawn_result {
-                    Ok(tuple) => tuple,
-                    Err(e) => {
-                        registry.fail(&task_id, &format!("idat task panicked: {e}"));
-                        return;
-                    }
-                };
+                if cancel_token.is_cancelled() {
+                    registry
+                        .finish_cancelled(&task_id, "Cancelled after the idat subprocess settled");
+                    return;
+                }
 
                 // Clean up the temporary load script now; the guard still covers early returns above.
                 script_cleanup.cleanup_now();
 
-                if exit_code != 0 || !out_path.exists() {
-                    let log_tail = log_out
+                if exit_code != 0 || !out_i64.exists() {
+                    let log_tail = log_path
                         .as_ref()
                         .and_then(|p| std::fs::read_to_string(p).ok())
                         .map(|s| {
@@ -1187,12 +1471,19 @@ impl IdaMcpServer {
                     if let Some(tail) = log_tail {
                         msg.push_str(&format!("\nlog (last 20 lines):\n{tail}"));
                     }
-                    warn!(exit_code, task_id = %task_id, "idat failed");
-                    registry.fail(&task_id, &msg);
+                    remove_partial_idat_outputs(&out_i64);
+                    warn!(exit_code, "idat failed");
+                    Self::complete_background_tool_error(
+                        &task_id,
+                        &registry,
+                        &ToolError::OpenFailed(msg),
+                        &cancel_token,
+                        "Cancelled after the idat subprocess settled",
+                    );
                     return;
                 }
 
-                info!(task_id = %task_id, "idat completed, opening .i64");
+                info!("idat completed, opening .i64");
                 registry.update_message(&task_id, "Opening database with idalib...");
                 (out_i64, None, true, false)
             }
@@ -1201,7 +1492,7 @@ impl IdaMcpServer {
         // Phase 2: open the database with idalib.
         let open_path_str = open_path.display().to_string();
         let open_result = worker
-            .open_observed(
+            .open_observed_with_generation(
                 &open_path_str,
                 false,
                 None,
@@ -1218,13 +1509,33 @@ impl IdaMcpServer {
             )
             .await;
 
-        let db_info = match open_result {
-            Ok(info) => info,
+        let opened = match open_result {
+            Ok(opened) => {
+                if cancel_token.is_cancelled() {
+                    Self::finish_dsc_cancellation_after_open(
+                        &task_id,
+                        &registry,
+                        &worker,
+                        opened.generation,
+                    )
+                    .await;
+                    return;
+                }
+                opened
+            }
             Err(e) => {
-                registry.fail(&task_id, &e.to_string());
+                Self::complete_background_tool_error(
+                    &task_id,
+                    &registry,
+                    &e,
+                    &cancel_token,
+                    "Cancelled after the DSC open operation settled",
+                );
                 return;
             }
         };
+        let db_info = opened.info;
+        let database_generation = opened.generation;
 
         let mut loaded_images = Vec::new();
         let mut analysis_status = None;
@@ -1232,14 +1543,29 @@ impl IdaMcpServer {
         let mut next_steps = None;
         if load_images_with_dscu {
             registry.update_message(&task_id, "Loading DSC module through ida_dscu...");
-            match worker.dsc_load_image(&module, Some(600)).await {
+            let module_result = worker
+                .dsc_load_image_for_generation(&module, Some(600), Some(database_generation))
+                .await;
+            if cancel_token.is_cancelled() {
+                Self::finish_dsc_cancellation_after_open(
+                    &task_id,
+                    &registry,
+                    &worker,
+                    database_generation,
+                )
+                .await;
+                return;
+            }
+            match module_result {
                 Ok(image) => loaded_images.push(image),
                 Err(e) => {
-                    Self::fail_dsc_background_after_open(
+                    Self::finish_dsc_tool_error_after_open(
                         &task_id,
                         &registry,
                         &worker,
-                        format!("Failed to load DSC module {module}: {e}"),
+                        database_generation,
+                        ToolError::IdaError(format!("Failed to load DSC module {module}: {e}")),
+                        &cancel_token,
                     )
                     .await;
                     return;
@@ -1248,18 +1574,41 @@ impl IdaMcpServer {
 
             for framework in &frameworks {
                 if cancel_token.is_cancelled() {
-                    registry.finish_cancelled(&task_id, "Cancelled by session shutdown");
+                    Self::finish_dsc_cancellation_after_open(
+                        &task_id,
+                        &registry,
+                        &worker,
+                        database_generation,
+                    )
+                    .await;
                     return;
                 }
                 registry.update_message(&task_id, &format!("Loading DSC framework {framework}..."));
-                match worker.dsc_load_image(framework, Some(600)).await {
+                let framework_result = worker
+                    .dsc_load_image_for_generation(framework, Some(600), Some(database_generation))
+                    .await;
+                if cancel_token.is_cancelled() {
+                    Self::finish_dsc_cancellation_after_open(
+                        &task_id,
+                        &registry,
+                        &worker,
+                        database_generation,
+                    )
+                    .await;
+                    return;
+                }
+                match framework_result {
                     Ok(image) => loaded_images.push(image),
                     Err(e) => {
-                        Self::fail_dsc_background_after_open(
+                        Self::finish_dsc_tool_error_after_open(
                             &task_id,
                             &registry,
                             &worker,
-                            format!("Failed to load DSC framework {framework}: {e}"),
+                            database_generation,
+                            ToolError::IdaError(format!(
+                                "Failed to load DSC framework {framework}: {e}"
+                            )),
+                            &cancel_token,
                         )
                         .await;
                         return;
@@ -1267,7 +1616,20 @@ impl IdaMcpServer {
                 }
             }
 
-            analysis_status = match worker.analysis_status().await {
+            let analysis_status_result = worker
+                .analysis_status_for_generation(Some(database_generation))
+                .await;
+            if cancel_token.is_cancelled() {
+                Self::finish_dsc_cancellation_after_open(
+                    &task_id,
+                    &registry,
+                    &worker,
+                    database_generation,
+                )
+                .await;
+                return;
+            }
+            analysis_status = match analysis_status_result {
                 Ok(status) => Some(status),
                 Err(err) => {
                     warn!(module = %module, error = %err, "failed to fetch analysis_status after background open_dsc");
@@ -1279,6 +1641,17 @@ impl IdaMcpServer {
                 analysis_ready,
                 "Proceed with xrefs/decompile/list_functions for the loaded DSC module.",
             ));
+        }
+
+        if cancel_token.is_cancelled() {
+            Self::finish_dsc_cancellation_after_open(
+                &task_id,
+                &registry,
+                &worker,
+                database_generation,
+            )
+            .await;
+            return;
         }
 
         let close_token = match (mode, owner_session_id.as_deref()) {
@@ -1308,8 +1681,21 @@ impl IdaMcpServer {
             apply_close_metadata(map, close_token, close_hint_for(mode, worker.is_pooled()));
         }
 
-        info!(task_id = %task_id, "DSC background task completed");
-        registry.complete(&task_id, value);
+        match registry.complete_or_defer_cancellation(&task_id, value, &cancel_token) {
+            task::TaskCompletionDecision::Completed => {
+                info!("DSC background task completed");
+            }
+            task::TaskCompletionDecision::CancellationPending => {
+                Self::finish_dsc_cancellation_after_open(
+                    &task_id,
+                    &registry,
+                    &worker,
+                    database_generation,
+                )
+                .await;
+            }
+            task::TaskCompletionDecision::Unchanged => {}
+        }
     }
 }
 
@@ -1353,10 +1739,42 @@ fn close_hint_for(mode: ServerMode, pooled: bool) -> &'static str {
         }
         (ServerMode::Stdio, _) => "Call close_idb when done to release locks for other sessions.",
         (ServerMode::Http, false) => {
-            "In multi-client (HTTP/SSE) mode, close_idb accepts the close_token returned by open_idb. The owning session can also close without re-sending the token, and close_idb(force=true) can recover from a lost session."
+            "In HTTP/SSE mode, keep the close_token returned by open_idb. Sessionless MCP 2026 and non-owning legacy contexts must pass it to close_idb; the owning legacy session can close directly. If the token is lost, close_idb(force=true) can recover the shared IDA context."
         }
         (ServerMode::Worker, _) => {
             "Child worker mode is managed by the parent router; close_idb is normally called by the parent."
+        }
+    }
+}
+
+/// Stop and reap an idat child before removing database artifacts that cannot
+/// be trusted after cancellation or a wait failure.
+async fn stop_idat_and_remove_partial_outputs(
+    child: &mut tokio::process::Child,
+    out_i64: &std::path::Path,
+) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+    remove_partial_idat_outputs(out_i64);
+}
+
+/// Best-effort removal of what an incomplete idat run leaves behind: the packed
+/// `.i64` (which `dsc_open_plan` would reuse as-is on the next `open_dsc`)
+/// and the unpacked database components idat works in before packing.
+fn remove_partial_idat_outputs(out_i64: &std::path::Path) {
+    let mut paths = vec![out_i64.to_path_buf()];
+    for ext in ["id0", "id1", "id2", "nam", "til"] {
+        paths.push(out_i64.with_extension(ext));
+    }
+    for path in paths {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                info!(path = %path.display(), "removed untrusted partial idat output");
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                warn!(path = %path.display(), error = %e, "failed to remove partial idat output");
+            }
         }
     }
 }
@@ -1385,7 +1803,7 @@ fn apply_close_metadata(
             map.insert(
                 "close_hint".to_string(),
                 json!(format!(
-                    "The open database is currently owned by HTTP session {owner_session_id}. Reuse that session to call close_idb, or call close_idb(force=true) to recover if the owning session was lost."
+                    "The open database is currently owned by HTTP context {owner_session_id}. Provide its close_token to close_idb, or call close_idb(force=true) if that token was lost."
                 )),
             );
             map.insert(
@@ -1395,7 +1813,7 @@ fn apply_close_metadata(
             map.insert(
                 "close_recovery_hint".to_string(),
                 json!(
-                    "If the original MCP HTTP session was lost, call close_idb(force=true) from a trusted recovery session."
+                    "If the original close_token was lost, call close_idb(force=true) from a trusted client."
                 ),
             );
         }
@@ -1420,22 +1838,24 @@ impl IdaMcpServer {
         poll task_status(analysis_task_id) when present. \
         Call tool_help('open_idb') for full details."
     )]
-    #[instrument(skip(self), fields(path = %req.path))]
+    #[instrument(skip_all, fields(path = %req.path, mrtr_retry = request_state.is_some()))]
     async fn open_idb(
         &self,
         ctx: RequestContext<RoleServer>,
+        RequestState(request_state): RequestState,
+        ToolInputResponses(input_responses): ToolInputResponses,
         Parameters(req): Parameters<OpenIdbRequest>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         debug!("Tool call: open_idb");
         let path = req.path.trim().to_string();
         // Validate path (prevent directory traversal, check extension)
         if !Self::validate_path(&path) {
-            return Ok(ToolError::InvalidPath(path).to_tool_result());
+            return Ok(ToolError::InvalidPath(path).to_tool_result().into());
         }
-        let timeout_secs = try_param!(parse_optional_unsigned::<u64>(
-            req.timeout_secs,
-            "timeout_secs"
-        ));
+        let timeout_secs = match parse_optional_unsigned::<u64>(req.timeout_secs, "timeout_secs") {
+            Ok(timeout_secs) => timeout_secs,
+            Err(error) => return Ok(error.to_tool_result().into()),
+        };
 
         let debug_info_path = req.normalized_debug_info_path();
         let file_type = req.normalized_file_type();
@@ -1461,9 +1881,25 @@ impl IdaMcpServer {
             None
         };
         let route_to_background = match large_input_size {
-            Some(size) => {
-                self.choose_open_idb_background(&ctx, &path, size, timeout_secs)
-                    .await
+            Some(size) => match self
+                .choose_open_idb_background(
+                    &ctx,
+                    &path,
+                    size,
+                    timeout_secs,
+                    request_state,
+                    input_responses,
+                )
+                .await?
+            {
+                OpenIdbBackgroundDecision::Ready(background) => background,
+                OpenIdbBackgroundDecision::InputRequired(result) => return Ok(result.into()),
+            },
+            None if request_state.is_some() || input_responses.is_some() => {
+                return Err(McpError::invalid_params(
+                    "requestState/inputResponses do not match an active open_idb elicitation",
+                    None,
+                ));
             }
             None => false,
         };
@@ -1502,9 +1938,14 @@ impl IdaMcpServer {
             Ok(info) => {
                 let close_token = self.http_close_grant();
                 let analysis_task = if route_to_background && !info.analysis_status.auto_is_ok {
-                    Some(match self.spawn_analyze_funcs_task() {
-                        Ok(task_id) => (task_id, "started"),
-                        Err(existing_id) => (existing_id, "already_running"),
+                    let cancel_token = self.background_lifetime(&ctx.meta).child_token();
+                    let owner = self.task_owner(&ctx.meta);
+                    Some(match self.spawn_analyze_funcs_task(&owner, cancel_token) {
+                        Ok(task_id) => Ok((task_id, "started")),
+                        Err(task::TaskCreateError::AlreadyRunning(existing_id)) => {
+                            Ok((existing_id, "already_running"))
+                        }
+                        Err(error) => Err(task_create_error_to_tool_error(error).to_string()),
                     })
                 } else {
                     None
@@ -1514,7 +1955,8 @@ impl IdaMcpServer {
                     Err(_) => {
                         return Ok(CallToolResult::success(vec![Content::text(format!(
                             "{info:?}"
-                        ))]));
+                        ))])
+                        .into());
                     }
                 };
                 if let Value::Object(map) = &mut value {
@@ -1535,20 +1977,35 @@ impl IdaMcpServer {
                         map.insert("session_id".to_string(), json!(self.session_id));
                         self.apply_close_metadata(map, close_token);
                     }
-                    if let Some((task_id, status)) = analysis_task {
-                        let reason = format!(
-                            "Input size exceeded {} MiB; auto-analysis routed to a background task. Poll task_status(task_id) for progress.",
-                            OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES / (1024 * 1024)
-                        );
-                        map.insert("analysis_background".to_string(), json!(true));
-                        map.insert("analysis_task_id".to_string(), json!(task_id));
-                        map.insert("analysis_task_status".to_string(), json!(status));
-                        map.insert("analysis_background_reason".to_string(), json!(reason));
+                    if let Some(analysis_task) = analysis_task {
+                        match analysis_task {
+                            Ok((task_id, status)) => {
+                                let reason = format!(
+                                    "Input size exceeded {} MiB; auto-analysis routed to a background task. Poll task_status(task_id) for progress.",
+                                    OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES / (1024 * 1024)
+                                );
+                                map.insert("analysis_background".to_string(), json!(true));
+                                map.insert("analysis_started".to_string(), json!(true));
+                                map.insert("analysis_task_id".to_string(), json!(task_id));
+                                map.insert("analysis_task_status".to_string(), json!(status));
+                                map.insert("analysis_background_reason".to_string(), json!(reason));
+                            }
+                            Err(error) => {
+                                map.insert("analysis_background".to_string(), json!(false));
+                                map.insert("analysis_started".to_string(), json!(false));
+                                map.insert(
+                                    "analysis_task_status".to_string(),
+                                    json!("not_started"),
+                                );
+                                map.insert("analysis_background_error".to_string(), json!(error));
+                            }
+                        }
                     }
                 }
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&value).unwrap_or_else(|_| format!("{value:?}")),
-                )]))
+                )])
+                .into())
             }
             Err(ForegroundOperationError::TimedOut {
                 timeout_secs,
@@ -1559,12 +2016,14 @@ impl IdaMcpServer {
                 &snapshot,
                 None,
             ))
-            .to_tool_result()),
+            .to_tool_result()
+            .into()),
             Err(ForegroundOperationError::Cancelled { snapshot }) => Ok(ToolError::Cancelled(
                 Self::operation_cancelled_message("open_idb", &snapshot),
             )
-            .to_tool_result()),
-            Err(ForegroundOperationError::Tool(error)) => Ok(error.to_tool_result()),
+            .to_tool_result()
+            .into()),
+            Err(ForegroundOperationError::Tool(error)) => Ok(error.to_tool_result().into()),
         }
     }
 
@@ -1598,6 +2057,16 @@ impl IdaMcpServer {
             .min(OPEN_IDB_ELICITATION_TIMEOUT_SECS)
     }
 
+    fn open_idb_background_prompt(path: &str, size_bytes: u64) -> String {
+        let size_mib = size_bytes / (1024 * 1024);
+        let threshold_mib = OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES / (1024 * 1024);
+        format!(
+            "'{path}' is {size_mib} MiB (threshold {threshold_mib} MiB). \
+             Run auto-analysis as a background task with no timeout? \
+             Choosing 'no' runs it inline (capped at the foreground timeout)."
+        )
+    }
+
     /// Decide whether `open_idb` should route auto-analysis to a background
     /// task. Asks the user via MCP elicitation when the client advertises the
     /// capability; falls back to "background" silently otherwise so large
@@ -1610,25 +2079,41 @@ impl IdaMcpServer {
         path: &str,
         size_bytes: u64,
         request_timeout_secs: Option<u64>,
-    ) -> bool {
+        request_state: Option<String>,
+        input_responses: Option<InputResponses>,
+    ) -> Result<OpenIdbBackgroundDecision, McpError> {
         use rmcp::service::{ElicitationError, ServiceError};
 
         let size_mib = size_bytes / (1024 * 1024);
-        let threshold_mib = OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES / (1024 * 1024);
+        let modern_protocol = ctx
+            .protocol_version()
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28);
+        if modern_protocol {
+            return self.modern_choose_open_idb_background(
+                ctx,
+                path,
+                size_bytes,
+                request_state,
+                input_responses,
+            );
+        }
+
+        if request_state.is_some() || input_responses.is_some() {
+            return Err(McpError::invalid_params(
+                "requestState and inputResponses require MCP 2026-07-28",
+                None,
+            ));
+        }
 
         if ctx.peer.supported_elicitation_modes().is_empty() {
             info!(
                 path,
                 size_mib, "client lacks elicitation; routing open_idb auto-analysis to background"
             );
-            return true;
+            return Ok(OpenIdbBackgroundDecision::Ready(true));
         }
 
-        let prompt = format!(
-            "'{path}' is {size_mib} MiB (threshold {threshold_mib} MiB). \
-            Run auto-analysis as a background task with no timeout? \
-            Choosing 'no' runs it inline (capped at the foreground timeout)."
-        );
+        let prompt = Self::open_idb_background_prompt(path, size_bytes);
 
         let elicitation_timeout_secs =
             Self::open_idb_elicitation_timeout_secs(request_timeout_secs);
@@ -1646,17 +2131,17 @@ impl IdaMcpServer {
                     size_mib,
                     "open_idb elicitation cancelled with client request"
                 );
-                return false;
+                return Ok(OpenIdbBackgroundDecision::Ready(false));
             }
             result = elicitation => result,
         };
 
-        match result {
+        let background = match result {
             Ok(Some(choice)) => choice.background.unwrap_or(true),
             // Some clients return Accept with no content for action-only
             // confirmations; treat that as a "yes, background".
-            // `Ok(None)` is not expected from rmcp 1.5 here, but keep the arm
-            // defensive in case the typed API broadens in a future release.
+            // `Ok(None)` is not expected from the current typed API, but keep
+            // the arm defensive in case that contract broadens later.
             Ok(None) | Err(ElicitationError::NoContent) => true,
             Err(ElicitationError::UserDeclined | ElicitationError::UserCancelled) => false,
             Err(ElicitationError::CapabilityNotSupported) => true,
@@ -1677,14 +2162,137 @@ impl IdaMcpServer {
                 );
                 true
             }
+        };
+        Ok(OpenIdbBackgroundDecision::Ready(background))
+    }
+
+    /// MCP 2026 (MRTR) preamble for the background decision: validates the
+    /// requestState/capability pairing before the sealed-state round-trip.
+    fn modern_choose_open_idb_background(
+        &self,
+        ctx: &RequestContext<RoleServer>,
+        path: &str,
+        size_bytes: u64,
+        request_state: Option<String>,
+        input_responses: Option<InputResponses>,
+    ) -> Result<OpenIdbBackgroundDecision, McpError> {
+        if request_state.is_none() && input_responses.is_some() {
+            return Err(McpError::invalid_params(
+                "inputResponses require a matching requestState",
+                None,
+            ));
         }
+        let supports_form_elicitation = ctx
+            .client_capabilities()
+            .and_then(|capabilities| capabilities.elicitation)
+            .and_then(|elicitation| elicitation.form)
+            .is_some();
+        if request_state.is_none() && !supports_form_elicitation {
+            info!(
+                path,
+                size_mib = size_bytes / (1024 * 1024),
+                "client lacks form elicitation; routing open_idb auto-analysis to background"
+            );
+            return Ok(OpenIdbBackgroundDecision::Ready(true));
+        }
+        if !supports_form_elicitation {
+            return Err(McpError::invalid_params(
+                "MRTR retry omitted the form elicitation capability",
+                None,
+            ));
+        }
+        self.modern_open_idb_background_decision(path, size_bytes, request_state, input_responses)
+    }
+
+    fn modern_open_idb_background_decision(
+        &self,
+        path: &str,
+        size_bytes: u64,
+        request_state: Option<String>,
+        input_responses: Option<InputResponses>,
+    ) -> Result<OpenIdbBackgroundDecision, McpError> {
+        const STAGE: &[u8] = b"open_idb/background-confirmation/v1";
+        const INPUT_KEY: &str = "background";
+
+        let associated_data = format!("tools/call:open_idb\0{path}\0{size_bytes}");
+        let Some(sealed) = request_state else {
+            if input_responses.is_some() {
+                return Err(McpError::invalid_params(
+                    "inputResponses require a matching requestState",
+                    None,
+                ));
+            }
+            let sealed = self.request_state_codec.seal_with(
+                STAGE,
+                &SealOptions::new()
+                    .associated_data(associated_data.as_bytes())
+                    .ttl(Duration::from_secs(OPEN_IDB_REQUEST_STATE_TTL_SECS)),
+            );
+            // Reuse the same schema the legacy elicitation path derives from
+            // `OpenIdbBackgroundChoice`, so the two protocols cannot drift.
+            let requested_schema = ElicitationSchema::from_type::<OpenIdbBackgroundChoice>()
+                .map_err(|error| {
+                    McpError::internal_error(
+                        format!("failed to build open_idb elicitation schema: {error}"),
+                        None,
+                    )
+                })?;
+            let mut input_requests = InputRequests::new();
+            input_requests.insert(
+                INPUT_KEY.to_string(),
+                InputRequest::Elicitation(ElicitRequest::new(
+                    ElicitRequestParams::FormElicitationParams {
+                        meta: None,
+                        message: Self::open_idb_background_prompt(path, size_bytes),
+                        requested_schema,
+                    },
+                )),
+            );
+            return Ok(OpenIdbBackgroundDecision::InputRequired(
+                InputRequiredResult::new(Some(input_requests), Some(sealed)),
+            ));
+        };
+
+        let opened = self
+            .request_state_codec
+            .open_with(&sealed, associated_data.as_bytes())
+            .map_err(|_| {
+                McpError::invalid_params("expired, tampered, or unknown requestState", None)
+            })?;
+        if opened != STAGE {
+            return Err(McpError::invalid_params(
+                "requestState belongs to a different MRTR stage",
+                None,
+            ));
+        }
+        let response = input_responses
+            .as_ref()
+            .and_then(|responses| responses.get(INPUT_KEY))
+            .ok_or_else(|| {
+                McpError::invalid_params("missing background elicitation response", None)
+            })?;
+        let response: ElicitResult = serde_json::from_value(response.clone()).map_err(|_| {
+            McpError::invalid_params("invalid background elicitation response action", None)
+        })?;
+        let background = match response.action {
+            ElicitationAction::Accept => response
+                .content
+                .and_then(|content| serde_json::from_value::<OpenIdbBackgroundChoice>(content).ok())
+                .and_then(|choice| choice.background)
+                .unwrap_or(true),
+            ElicitationAction::Decline | ElicitationAction::Cancel => false,
+            // `ElicitationAction` is #[non_exhaustive]; treat unknown future
+            // actions as a decline so we never background without consent.
+            _ => false,
+        };
+        Ok(OpenIdbBackgroundDecision::Ready(background))
     }
 
     #[tool(
         description = "Load external debug info (e.g., DWARF/dSYM) into the current database. \
         If path is omitted, attempts to locate a sibling .dSYM for the currently-open database."
     )]
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(has_path = req.path.is_some()))]
     async fn load_debug_info(
         &self,
         Parameters(req): Parameters<LoadDebugInfoRequest>,
@@ -1704,7 +2312,7 @@ impl IdaMcpServer {
 
     #[tool(description = "Report auto-analysis status (auto_is_ok, auto_state). \
         Use this to check whether analysis-dependent tools (xrefs, decompile) are fully ready.")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn analysis_status(&self) -> Result<CallToolResult, McpError> {
         debug!("Tool call: analysis_status");
         match self.worker.analysis_status().await {
@@ -1726,10 +2334,11 @@ impl IdaMcpServer {
 
     #[tool(description = "Close the currently open IDA database. \
         Call this when you're done analyzing to free resources. \
-        In HTTP/SSE mode, the owning session can close directly, provide the close_token returned by open_idb, \
-        or set force=true to recover from a lost owner session. \
-        The database can also be left open for the duration of the session.")]
-    #[instrument(skip(self))]
+        In legacy HTTP/SSE, the owning session can close directly. Otherwise, \
+        including MCP 2026, provide the close_token returned by open_idb, or \
+        set force=true from a trusted client if that token was lost. \
+        Stdio clients can close directly without a token.")]
+    #[instrument(skip_all, fields(has_token = req.token.is_some(), force = ?req.force))]
     async fn close_idb(
         &self,
         Parameters(req): Parameters<CloseIdbRequest>,
@@ -1757,7 +2366,7 @@ impl IdaMcpServer {
                             "closed": false,
                             "reason": "owner token required",
                             "owner_session_id": owner_session_id,
-                            "hint": "Reuse the owning HTTP session to call close_idb, provide the close_token from open_idb, or call close_idb(force=true) to recover if that session was lost."
+                            "hint": "Provide the close_token from open_idb, or call close_idb(force=true) from a trusted client if that token was lost."
                         }))
                         .unwrap_or_else(|_| "close_idb ignored: owner token required".to_string()),
                     )]));
@@ -1778,7 +2387,7 @@ impl IdaMcpServer {
 
     #[tool(description = "Discover available tools by query or category. \
         Use this to find the right tool for your task before calling tool_help for full details.")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn tool_catalog(
         &self,
         Parameters(req): Parameters<ToolCatalogRequest>,
@@ -1889,7 +2498,7 @@ impl IdaMcpServer {
     #[tool(
         description = "Get full documentation for a tool including description, parameters schema, and example."
     )]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn tool_help(
         &self,
         Parameters(req): Parameters<ToolHelpRequest>,
@@ -1943,7 +2552,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List all functions in the database (paginated).")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit))]
     async fn list_functions(
         &self,
         Parameters(req): Parameters<ListFunctionsRequest>,
@@ -1974,7 +2583,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List functions (ida-pro-mcp compatible alias).")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit, filter = ?req.filter))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit, filter = ?req.filter))]
     async fn list_funcs(
         &self,
         Parameters(req): Parameters<ListFunctionsRequest>,
@@ -2004,7 +2613,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Resolve a function name to its address")]
-    #[instrument(skip(self), fields(name = %req.name))]
+    #[instrument(skip_all, fields(name = %req.name))]
     async fn resolve_function(
         &self,
         Parameters(req): Parameters<ResolveFunctionRequest>,
@@ -2069,7 +2678,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get disassembly at an address")]
-    #[instrument(skip(self), fields(address = %req.address, count = req.count))]
+    #[instrument(skip_all, fields(address = %req.address, count = req.count))]
     async fn disasm(
         &self,
         Parameters(req): Parameters<DisasmRequest>,
@@ -2111,7 +2720,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get disassembly for a function by name")]
-    #[instrument(skip(self), fields(name = %req.name, count = req.count))]
+    #[instrument(skip_all, fields(name = %req.name, count = req.count))]
     async fn disasm_by_name(
         &self,
         Parameters(req): Parameters<DisasmByNameRequest>,
@@ -2154,7 +2763,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Decompile a function using Hex-Rays (if available)")]
-    #[instrument(skip(self), fields(address = %req.address))]
+    #[instrument(skip_all, fields(address = %req.address))]
     async fn decompile(
         &self,
         Parameters(req): Parameters<DecompileRequest>,
@@ -2197,7 +2806,7 @@ impl IdaMcpServer {
         that correspond to the given address(es). Useful for getting pseudocode for a basic block \
         or specific instruction. If end_address is provided, returns statements covering the range."
     )]
-    #[instrument(skip(self), fields(address = %req.address, end_address = ?req.end_address))]
+    #[instrument(skip_all, fields(address = %req.address, end_address = ?req.end_address))]
     async fn pseudocode_at(
         &self,
         Parameters(req): Parameters<PseudocodeAtRequest>,
@@ -2247,7 +2856,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List all segments in the database with their permissions and types")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn segments(&self) -> Result<CallToolResult, McpError> {
         debug!("Tool call: segments");
         match self.worker.segments().await {
@@ -2259,7 +2868,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List strings in the database with pagination and optional filter.")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit, filter = ?req.filter))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit, filter = ?req.filter))]
     async fn strings(
         &self,
         Parameters(req): Parameters<StringsRequest>,
@@ -2367,7 +2976,7 @@ impl IdaMcpServer {
         Paginated (default limit 1000, max 10000); when truncated=true, pass next_offset back \
         as offset to page through high-frequency targets."
     )]
-    #[instrument(skip(self), fields(address = %req.address))]
+    #[instrument(skip_all, fields(address = %req.address))]
     async fn xrefs_to(
         &self,
         Parameters(req): Parameters<XrefsRequest>,
@@ -2381,7 +2990,7 @@ impl IdaMcpServer {
         Paginated (default limit 1000, max 10000); when truncated=true, pass next_offset back \
         as offset to page through the remaining references."
     )]
-    #[instrument(skip(self), fields(address = %req.address))]
+    #[instrument(skip_all, fields(address = %req.address))]
     async fn xrefs_from(
         &self,
         Parameters(req): Parameters<XrefsRequest>,
@@ -2391,7 +3000,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List imports (external symbols) with pagination")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit))]
     async fn imports(
         &self,
         Parameters(req): Parameters<PaginatedRequest>,
@@ -2412,7 +3021,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List exports/names (public symbols) with pagination")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit))]
     async fn exports(
         &self,
         Parameters(req): Parameters<PaginatedRequest>,
@@ -2433,7 +3042,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get entry point addresses of the binary")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn entrypoints(&self) -> Result<CallToolResult, McpError> {
         debug!("Tool call: entrypoints");
         match self.worker.entrypoints().await {
@@ -2445,7 +3054,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read raw bytes from an address as hex string")]
-    #[instrument(skip(self), fields(size = req.size))]
+    #[instrument(skip_all, fields(size = req.size))]
     async fn get_bytes(
         &self,
         Parameters(req): Parameters<GetBytesRequest>,
@@ -2506,7 +3115,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get basic blocks of a function (control flow graph nodes)")]
-    #[instrument(skip(self), fields(address = %req.address))]
+    #[instrument(skip_all, fields(address = %req.address))]
     async fn basic_blocks(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2547,7 +3156,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get functions called BY a function (callees/children in call graph)")]
-    #[instrument(skip(self), fields(address = %req.address))]
+    #[instrument(skip_all, fields(address = %req.address))]
     async fn callees(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2588,7 +3197,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get functions that CALL a function (callers/parents in call graph)")]
-    #[instrument(skip(self), fields(address = %req.address))]
+    #[instrument(skip_all, fields(address = %req.address))]
     async fn callers(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2629,7 +3238,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get IDB metadata (ida-pro-mcp compatibility)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn idb_meta(&self) -> Result<CallToolResult, McpError> {
         debug!("Tool call: idb_meta");
         match self.worker.idb_meta().await {
@@ -2650,7 +3259,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Lookup functions by name or address (batch)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn lookup_funcs(
         &self,
         Parameters(req): Parameters<LookupFuncsRequest>,
@@ -2669,7 +3278,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List global names (non-function symbols).")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit, query = ?req.query))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit, query = ?req.query))]
     async fn list_globals(
         &self,
         Parameters(req): Parameters<ListGlobalsRequest>,
@@ -2697,7 +3306,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Analyze strings with xrefs (ida-pro-mcp compatibility).")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit, query = ?req.query))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit, query = ?req.query))]
     async fn analyze_strings(
         &self,
         Parameters(req): Parameters<AnalyzeStringsRequest>,
@@ -2725,7 +3334,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Find byte patterns (ida-pro-mcp compatibility).")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn find_bytes(
         &self,
         Parameters(req): Parameters<FindBytesRequest>,
@@ -2801,7 +3410,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Search for text or immediates (ida-pro-mcp compatibility).")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn search(
         &self,
         Parameters(req): Parameters<SearchRequest>,
@@ -2897,7 +3506,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read u8 values at address(es)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_u8(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2906,7 +3515,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read u16 values at address(es)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_u16(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2915,7 +3524,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read u32 values at address(es)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_u32(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2924,7 +3533,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read u64 values at address(es)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_u64(
         &self,
         Parameters(req): Parameters<AddressRequest>,
@@ -2933,7 +3542,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read string(s) at address(es)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_string(
         &self,
         Parameters(req): Parameters<GetStringRequest>,
@@ -2977,7 +3586,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get global value(s) by name or address")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn get_global_value(
         &self,
         Parameters(req): Parameters<GetGlobalValueRequest>,
@@ -3018,7 +3627,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Find paths between two addresses (CFG)")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn find_paths(
         &self,
         Parameters(req): Parameters<FindPathsRequest>,
@@ -3052,7 +3661,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Build a callgraph rooted at an address")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn callgraph(
         &self,
         Parameters(req): Parameters<CallGraphRequest>,
@@ -3099,7 +3708,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Compute xref matrix for a set of addresses")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn xref_matrix(
         &self,
         Parameters(req): Parameters<XrefMatrixRequest>,
@@ -3118,7 +3727,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Export functions (ida-pro-mcp compatibility)")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit))]
     async fn export_funcs(
         &self,
         Parameters(req): Parameters<ExportFuncsRequest>,
@@ -3162,7 +3771,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Convert integers between bases")]
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn int_convert(
         &self,
         Parameters(req): Parameters<IntConvertRequest>,
@@ -3261,7 +3870,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Look up Lumina metadata for a function without applying it")]
-    #[instrument(skip(self), fields(target_name = ?req.target_name))]
+    #[instrument(skip_all, fields(target_name = ?req.target_name))]
     async fn lumina_lookup(
         &self,
         Parameters(req): Parameters<LuminaLookupRequest>,
@@ -3289,7 +3898,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Pull and apply Lumina metadata to a function")]
-    #[instrument(skip(self), fields(target_name = ?req.target_name, force = req.force))]
+    #[instrument(skip_all, fields(target_name = ?req.target_name, force = req.force))]
     async fn lumina_apply(
         &self,
         Parameters(req): Parameters<LuminaApplyRequest>,
@@ -3473,7 +4082,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "List structs in the database with pagination and optional filter.")]
-    #[instrument(skip(self), fields(offset = req.offset, limit = req.limit, filter = ?req.filter))]
+    #[instrument(skip_all, fields(offset = req.offset, limit = req.limit, filter = ?req.filter))]
     async fn structs(
         &self,
         Parameters(req): Parameters<StructsRequest>,
@@ -3502,7 +4111,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Get info about a struct by ordinal or name")]
-    #[instrument(skip(self), fields(ordinal = req.ordinal, name = ?req.name))]
+    #[instrument(skip_all, fields(ordinal = req.ordinal, name = ?req.name))]
     async fn struct_info(
         &self,
         Parameters(req): Parameters<StructInfoRequest>,
@@ -3518,7 +4127,7 @@ impl IdaMcpServer {
     }
 
     #[tool(description = "Read values of a struct instance at an address")]
-    #[instrument(skip(self), fields(address = %req.address, ordinal = req.ordinal, name = ?req.name))]
+    #[instrument(skip_all, fields(address = %req.address, ordinal = req.ordinal, name = ?req.name))]
     async fn read_struct(
         &self,
         Parameters(req): Parameters<ReadStructRequest>,
@@ -3734,7 +4343,9 @@ impl IdaMcpServer {
             };
         }
         if req.background.unwrap_or(false) {
-            return Ok(self.analyze_funcs_background());
+            let cancel_token = self.background_lifetime(&ctx.meta).child_token();
+            let owner = self.task_owner(&ctx.meta);
+            return Ok(self.analyze_funcs_background(&owner, cancel_token));
         }
 
         let timeout_secs = try_param!(parse_optional_unsigned::<u64>(
@@ -3784,20 +4395,26 @@ impl IdaMcpServer {
     /// Spawn auto-analysis as a background task. Returns a task_id immediately;
     /// the IDA worker thread runs auto_wait() while task_status reads the registry
     /// without going through the worker. Only one analysis runs at a time (single
-    /// worker thread), so a fixed dedup key returns the existing task_id if one
-    /// is already in flight.
-    fn analyze_funcs_background(&self) -> CallToolResult {
-        let payload = match self.spawn_analyze_funcs_task() {
+    /// worker thread), so a fixed dedup key blocks another analysis while one
+    /// is already in flight. Only the same legacy session receives its existing
+    /// task ID; sessionless Runtime requests never do.
+    fn analyze_funcs_background(
+        &self,
+        owner: &task::TaskOwner,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> CallToolResult {
+        let payload = match self.spawn_analyze_funcs_task(owner, cancel_token) {
             Ok(task_id) => json!({
                 "status": "started",
                 "task_id": task_id,
                 "message": "Auto-analysis started in background. Poll task_status(task_id) for progress. Other tool calls will block until the IDA worker thread is free.",
             }),
-            Err(existing_id) => json!({
+            Err(task::TaskCreateError::AlreadyRunning(existing_id)) => json!({
                 "status": "already_running",
                 "task_id": existing_id,
                 "message": "Auto-analysis is already running. Poll task_status(task_id) for progress.",
             }),
+            Err(error) => return task_create_error_to_tool_error(error).to_tool_result(),
         };
         CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&payload).unwrap_or_default(),
@@ -3805,24 +4422,28 @@ impl IdaMcpServer {
     }
 
     /// Create the background auto-analysis task and spawn its worker future.
-    /// Returns `Ok(task_id)` on success, `Err(existing_task_id)` if one is
-    /// already in flight (deduplicated by the fixed key).
-    fn spawn_analyze_funcs_task(&self) -> Result<String, String> {
+    /// Returns `Ok(task_id)` on success or an error if keyed work is already in
+    /// flight. The error carries an existing ID only for the same legacy session.
+    fn spawn_analyze_funcs_task(
+        &self,
+        owner: &task::TaskOwner,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> Result<String, task::TaskCreateError> {
         let task_id = self.task_registry.create_keyed(
+            owner,
             "analyze",
             "analyze_funcs",
             "Waiting for IDA auto-analysis to finish",
         )?;
 
-        info!(task_id = %task_id, "Spawning background auto-analysis");
+        info!("Spawning background auto-analysis");
 
         let registry = self.task_registry.clone();
         let worker = self.worker.clone();
         let tid = task_id.clone();
-        let cancel_token = self.session_lifetime.child_token();
         let worker_cancel_token = cancel_token.clone();
 
-        let handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             // Bridge worker progress updates → task registry messages.
             // The drain task ends when tx is dropped after analyze_funcs_observed returns.
             let (tx, mut rx): (ProgressSender, ProgressReceiver) =
@@ -3836,21 +4457,40 @@ impl IdaMcpServer {
             });
 
             match worker
-                .analyze_funcs_unbounded_observed(Some(tx), Some(worker_cancel_token))
+                .analyze_funcs_unbounded_observed(Some(tx), Some(worker_cancel_token.clone()))
                 .await
             {
-                Ok(value) => {
-                    info!(task_id = %tid, "Background auto-analysis completed");
-                    registry.complete(&tid, value);
-                }
-                Err(e) => {
-                    warn!(task_id = %tid, error = %e, "Background auto-analysis failed");
-                    registry.fail(&tid, &e.to_string());
-                }
+                Ok(value) => match registry.complete_with_cancel_token(
+                    &tid,
+                    value,
+                    &worker_cancel_token,
+                    "Cancelled after auto-analysis settled",
+                ) {
+                    task::TaskSettlement::Completed => {
+                        info!("Background auto-analysis completed");
+                    }
+                    task::TaskSettlement::Cancelled => {
+                        info!("Background auto-analysis cancelled after work settled");
+                    }
+                    task::TaskSettlement::Failed | task::TaskSettlement::Unchanged => {}
+                },
+                Err(e) => match registry.complete_with_cancel_token(
+                    &tid,
+                    call_tool_result_to_value(&e.to_tool_result()),
+                    &worker_cancel_token,
+                    "Cancelled after auto-analysis settled",
+                ) {
+                    task::TaskSettlement::Completed => {
+                        warn!(error = %e, "Background auto-analysis completed with a tool error");
+                    }
+                    task::TaskSettlement::Cancelled => {
+                        info!("Background auto-analysis cancelled after work settled");
+                    }
+                    task::TaskSettlement::Failed | task::TaskSettlement::Unchanged => {}
+                },
             }
         });
-        self.task_registry
-            .set_handle_with_cancel_token(&task_id, handle, cancel_token);
+        self.task_registry.set_cancel_token(&task_id, cancel_token);
         Ok(task_id)
     }
 
@@ -3911,15 +4551,18 @@ impl IdaMcpServer {
     #[tool(
         description = "Open a dyld_shared_cache and load a single dylib (e.g. \
         '/usr/lib/libobjc.A.dylib'). Use instead of open_idb for Apple DSCs. \
-        On IDA 9.4, opens the DSC header directly in a background task and loads modules through ida_dscu. \
-        On older IDA builds, if .i64 exists, opens immediately; otherwise returns \
-        task_id and creates it with idat in the background. Poll task_status(task_id). \
+        If a previously generated .i64 exists for this DSC, opens it immediately, \
+        preserving prior analysis. Otherwise on IDA 9.4, opens the DSC header \
+        directly in a background task and loads modules through ida_dscu; on \
+        older IDA builds, returns task_id and creates the .i64 with idat in the \
+        background. Poll task_status(task_id). \
         Use dsc_add_dylib to load more modules, dsc_add_region for raw regions. \
         Call tool_help('open_dsc') for full details."
     )]
-    #[instrument(skip(self), fields(path = %req.path, arch = %req.arch, module = %req.module))]
+    #[instrument(skip_all, fields(path = %req.path, arch = %req.arch, module = %req.module))]
     async fn open_dsc(
         &self,
+        ctx: RequestContext<RoleServer>,
         Parameters(req): Parameters<OpenDscRequest>,
     ) -> Result<CallToolResult, McpError> {
         debug!("Tool call: open_dsc");
@@ -3943,12 +4586,27 @@ impl IdaMcpServer {
         let frameworks = req.frameworks.unwrap_or_default();
         let dsc_path = std::path::Path::new(&req.path);
         let out_i64 = dsc_path.with_extension("i64");
+        // Reuse order: a sibling .i64 (legacy idat output or user-provided)
+        // first, then the 9.4 direct-path cache. Pre-9.4 never considers the
+        // cache — those databases were written by a newer IDA and cannot be
+        // opened there.
+        let cache_i64 = direct_dsc_cache_i64_path(dsc_path);
+        let existing_i64 = if out_i64.exists() {
+            Some(out_i64.clone())
+        } else if idalib::SDK_VERSION >= (9, 4) && cache_i64.exists() {
+            Some(cache_i64.clone())
+        } else {
+            None
+        };
 
-        match dsc_open_plan(idalib::SDK_VERSION, out_i64.exists()) {
+        match dsc_open_plan(idalib::SDK_VERSION, existing_i64.is_some()) {
             // Existing .i64 databases are already in IDA's database format.
             DscOpenPlan::DirectExistingI64 => {
+                // `existing_i64` is Some whenever this plan is selected; the
+                // fallback only guards the type system.
+                let existing = existing_i64.unwrap_or(out_i64);
                 return self
-                    .open_dsc_direct(&out_i64, None, &req.module, &frameworks)
+                    .open_dsc_direct(&existing, None, &req.module, &frameworks)
                     .await;
             }
             // IDA 9.4 exposes ida_dscu/dscu_svc_t: the loader can open the DSC
@@ -3957,11 +4615,8 @@ impl IdaMcpServer {
             // Do not pass the legacy -T file-type selector here. IDA 9.4's
             // direct idalib open path rejects it with "Unknown switch '-T'".
             DscOpenPlan::BackgroundDirectRawDsc => {
-                let idb_out = match direct_dsc_temp_i64_path(dsc_path) {
-                    Ok(path) => path,
-                    Err(err) => return Ok(err.to_tool_result()),
-                };
-                let ctx = DscBackgroundCtx {
+                let idb_out = cache_i64;
+                let dsc_ctx = DscBackgroundCtx {
                     open: DscBackgroundOpen::DirectRawDsc {
                         open_path: dsc_path.to_path_buf(),
                         idb_out: idb_out.clone(),
@@ -3972,12 +4627,14 @@ impl IdaMcpServer {
                         .then(|| self.session_id.clone()),
                 };
                 return self.start_dsc_background(
+                    &self.task_owner(&ctx.meta),
                     dsc_path.display().to_string(),
                     &format!(
                         "Opening DSC directly with idalib (idb_out={})...",
                         idb_out.display()
                     ),
-                    ctx,
+                    dsc_ctx,
+                    self.background_lifetime(&ctx.meta).child_token(),
                 );
             }
             DscOpenPlan::LegacyIdatBackground => {}
@@ -4018,7 +4675,7 @@ impl IdaMcpServer {
         );
         let dedup_key = out_i64.display().to_string();
 
-        let ctx = DscBackgroundCtx {
+        let dsc_ctx = DscBackgroundCtx {
             open: DscBackgroundOpen::LegacyIdat {
                 idat,
                 idat_args,
@@ -4031,13 +4688,19 @@ impl IdaMcpServer {
             owner_session_id: matches!(self.mode, ServerMode::Http)
                 .then(|| self.session_id.clone()),
         };
-        self.start_dsc_background(dedup_key, "Running idat to create .i64 from DSC...", ctx)
+        self.start_dsc_background(
+            &self.task_owner(&ctx.meta),
+            dedup_key,
+            "Running idat to create .i64 from DSC...",
+            dsc_ctx,
+            self.background_lifetime(&ctx.meta).child_token(),
+        )
     }
 
     #[tool(description = "Load an additional dylib into an open DSC database \
         (requires prior open_dsc). Skips full auto-analysis for speed; \
         check analysis_status and run analyze_funcs if needed.")]
-    #[instrument(skip(self), fields(module = %req.module))]
+    #[instrument(skip_all, fields(module = %req.module))]
     async fn dsc_add_dylib(
         &self,
         Parameters(req): Parameters<DscAddDylibRequest>,
@@ -4124,7 +4787,7 @@ impl IdaMcpServer {
         (data/GOT/stub areas; one address per call; requires prior open_dsc). \
         Skips full auto-analysis."
     )]
-    #[instrument(skip(self), fields(address = ?req.address))]
+    #[instrument(skip_all, fields(address = ?req.address))]
     async fn dsc_add_region(
         &self,
         Parameters(req): Parameters<DscAddRegionRequest>,
@@ -4216,14 +4879,16 @@ impl IdaMcpServer {
         'failed' (with an error message), or 'cancelled'. \
         Use the task_id returned by open_dsc."
     )]
-    #[instrument(skip(self), fields(task_id = %req.task_id))]
+    #[instrument(skip_all)]
     async fn task_status(
         &self,
+        ctx: RequestContext<RoleServer>,
         Parameters(req): Parameters<TaskStatusRequest>,
     ) -> Result<CallToolResult, McpError> {
         debug!("Tool call: task_status");
 
-        let state = match self.task_registry.get(&req.task_id) {
+        let owner = self.task_owner(&ctx.meta);
+        let state = match self.task_registry.get_for_owner(&owner, &req.task_id) {
             Some(s) => s,
             None => {
                 return Ok(
@@ -4278,7 +4943,7 @@ impl IdaMcpServer {
         or 'file' (path to .py), not both. Returns captured stdout/stderr. \
         Full access to ida_*, idc, idautils."
     )]
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(code_len = req.code.as_ref().map_or(0, String::len)))]
     async fn run_script(
         &self,
         ctx: RequestContext<RoleServer>,
@@ -4672,8 +5337,29 @@ fn tool_params_schema(name: &str) -> Option<Value> {
 use rmcp::model::*;
 use rmcp::service::{RequestContext, RoleServer};
 
-/// Convert our internal `TaskState` to the rmcp `Task` model.
-fn task_state_to_mcp(state: &task::TaskState) -> rmcp::model::Task {
+/// All supported versions, oldest first. The final entry must stay the only
+/// modern (sessionless) protocol: pooled workers advertise everything before
+/// it, because their worker lease is bound to a legacy HTTP session.
+const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+    ProtocolVersion::V_2026_07_28,
+];
+
+fn supported_protocol_versions(pooled: bool) -> Cow<'static, [ProtocolVersion]> {
+    if pooled {
+        let (legacy, _modern) =
+            SUPPORTED_PROTOCOL_VERSIONS.split_at(SUPPORTED_PROTOCOL_VERSIONS.len() - 1);
+        Cow::Borrowed(legacy)
+    } else {
+        Cow::Borrowed(SUPPORTED_PROTOCOL_VERSIONS)
+    }
+}
+
+/// Convert our internal `TaskState` to the base rmcp `Task` model.
+fn task_state_to_mcp_task(state: &task::TaskState) -> rmcp::model::Task {
     let status = match state.status {
         task::TaskStatus::Running => rmcp::model::TaskStatus::Working,
         task::TaskStatus::Completed => rmcp::model::TaskStatus::Completed,
@@ -4687,10 +5373,37 @@ fn task_state_to_mcp(state: &task::TaskState) -> rmcp::model::Task {
         state.updated_at_iso.clone(),
     )
     .with_status_message(state.message.clone())
-    // Terminal tasks are retained on a best-effort basis and can be
-    // evicted once the in-memory cap is exceeded.
-    .with_ttl(task::TASK_RETENTION_TTL_MS)
-    .with_poll_interval(5000)
+    .with_ttl_ms(task::TASK_RETENTION_TTL_MS)
+    .with_poll_interval_ms(5000)
+}
+
+fn value_as_json_object(value: Value) -> JsonObject {
+    match value {
+        Value::Object(object) => object,
+        other => {
+            let mut object = JsonObject::new();
+            object.insert("value".to_string(), other);
+            object
+        }
+    }
+}
+
+fn task_state_to_detailed_task(state: task::TaskState) -> DetailedTask {
+    let base = task_state_to_mcp_task(&state);
+    let payload = match state.status {
+        task::TaskStatus::Running => TaskPayload::Working,
+        task::TaskStatus::Completed => TaskPayload::Completed {
+            result: value_as_json_object(task_payload_result_value(state.result)),
+        },
+        task::TaskStatus::Failed => TaskPayload::Failed {
+            error: value_as_json_object(json!({
+                "code": ErrorCode::INTERNAL_ERROR.0,
+                "message": state.message,
+            })),
+        },
+        task::TaskStatus::Cancelled => TaskPayload::Cancelled,
+    };
+    DetailedTask::new(base, payload)
 }
 
 fn call_tool_result_to_value(result: &CallToolResult) -> Value {
@@ -4722,130 +5435,124 @@ fn task_payload_result_value(result: Option<Value>) -> Value {
     }
 }
 
+fn task_id_from_call_tool_result(result: &CallToolResult) -> Option<String> {
+    result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .and_then(|text| serde_json::from_str::<Value>(&text.text).ok())
+        .and_then(|value| value.get("task_id")?.as_str().map(str::to_string))
+}
+
+fn task_create_error_to_tool_error(error: task::TaskCreateError) -> ToolError {
+    match error {
+        task::TaskCreateError::AlreadyRunning(_) => ToolError::Busy,
+        task::TaskCreateError::ExistingTaskIdIsPrivate => ToolError::BackgroundTaskHandlePrivate,
+        task::TaskCreateError::CapacityExceeded { max_entries } => {
+            ToolError::BackgroundTaskRegistryFull { max: max_entries }
+        }
+    }
+}
+
+/// SEP-2663 `tasks/update` semantics: unknown task ids are an invalid-params
+/// error, while responses delivered to a known task are acknowledged with an
+/// empty result even when unknown or superseded. No task here ever enters
+/// input_required (open_idb's MRTR happens at call level), so every delivered
+/// response falls into that ignored-not-error bucket.
+fn apply_task_update(
+    task_registry: &task::TaskRegistry,
+    owner: &task::TaskOwner,
+    task_id: &str,
+) -> Result<(), McpError> {
+    if task_registry.get_for_owner(owner, task_id).is_none() {
+        return Err(McpError::invalid_params(
+            "Unknown task_id",
+            Some(json!({ "task_id": task_id })),
+        ));
+    }
+    Ok(())
+}
+
+fn materialize_task_response(
+    task_registry: &task::TaskRegistry,
+    should_materialize: bool,
+    response: CallToolResponse,
+) -> Result<CallToolResponse, McpError> {
+    if !should_materialize {
+        return Ok(response);
+    }
+    let CallToolResponse::Complete(result) = response else {
+        return Ok(response);
+    };
+    let Some(task_id) = task_id_from_call_tool_result(&result) else {
+        return Ok(CallToolResponse::Complete(result));
+    };
+    let state = task_registry
+        .get(&task_id)
+        .ok_or_else(|| McpError::internal_error(format!("Task {task_id} disappeared"), None))?;
+    Ok(CreateTaskResult::new(task_state_to_mcp_task(&state)).into())
+}
+
 #[tool_handler(router = self.tool_mux)]
 impl ServerHandler for IdaMcpServer {
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        supported_protocol_versions(self.worker.is_pooled())
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
-                .enable_tasks_with(rmcp::model::TasksCapability::server_default())
+                .enable_tasks()
                 .build(),
         )
         .with_instructions(self.instructions())
     }
 
-    async fn enqueue_task(
-        &self,
-        request: CallToolRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> Result<CreateTaskResult, McpError> {
-        // Delegate to the regular tool handler and wrap the result
-        // into the task protocol.  For most tools the call completes
-        // inline.  For `open_dsc`, the tool creates a background
-        // task and returns a task_id — we re-use that ID.
-        let result = self.call_tool(request, context).await?;
-
-        // Check if the result contains a task_id from open_dsc.
-        let task_id = result
-            .content
-            .first()
-            .and_then(|c| c.as_text())
-            .and_then(|t| serde_json::from_str::<Value>(&t.text).ok())
-            .and_then(|v| v.get("task_id")?.as_str().map(String::from));
-
-        if let Some(tid) = task_id {
-            let state = self
-                .task_registry
-                .get(&tid)
-                .ok_or_else(|| McpError::internal_error(format!("Task {tid} disappeared"), None))?;
-            Ok(CreateTaskResult::new(task_state_to_mcp(&state)))
-        } else {
-            // Inline completion — no background work, but still register a completed
-            // task so tasks/get and tasks/result remain resolvable for this task_id.
-            let payload = call_tool_result_to_value(&result);
-            let id = self.task_registry.create_completed("Completed", payload);
-            let state = self
-                .task_registry
-                .get(&id)
-                .ok_or_else(|| McpError::internal_error(format!("Task {id} disappeared"), None))?;
-            Ok(CreateTaskResult::new(task_state_to_mcp(&state)))
-        }
-    }
-
-    async fn list_tasks(
-        &self,
-        _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ListTasksResult, McpError> {
-        let tasks: Vec<rmcp::model::Task> = self
-            .task_registry
-            .list_all()
-            .iter()
-            .map(task_state_to_mcp)
-            .collect();
-        Ok(ListTasksResult::new(tasks))
-    }
-
-    async fn get_task_info(
+    async fn get_task(
         &self,
         request: GetTaskParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<GetTaskResult, McpError> {
-        let state = self.task_registry.get(&request.task_id).ok_or_else(|| {
-            McpError::invalid_params(
-                "Unknown task_id",
-                Some(json!({ "task_id": request.task_id })),
-            )
-        })?;
-        Ok(GetTaskResult::new(task_state_to_mcp(&state)))
+        let owner = self.task_owner(&context.meta);
+        let state = self
+            .task_registry
+            .get_for_owner(&owner, &request.task_id)
+            .ok_or_else(|| {
+                McpError::invalid_params(
+                    "Unknown task_id",
+                    Some(json!({ "task_id": request.task_id })),
+                )
+            })?;
+        Ok(GetTaskResult::new(task_state_to_detailed_task(state)))
     }
 
-    async fn get_task_result(
+    async fn update_task(
         &self,
-        request: GetTaskPayloadParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<GetTaskPayloadResult, McpError> {
-        let state = self.task_registry.get(&request.task_id);
-        match state {
-            Some(s) if s.status == task::TaskStatus::Completed => Ok(GetTaskPayloadResult::new(
-                task_payload_result_value(s.result),
-            )),
-            Some(s) if s.status == task::TaskStatus::Failed => {
-                Err(McpError::internal_error(s.message, None))
-            }
-            Some(s) if s.status == task::TaskStatus::Cancelled => {
-                Err(McpError::internal_error("Task was cancelled", None))
-            }
-            Some(_) => Err(McpError::internal_error(
-                "Task is still running; poll tasks/get first",
-                None,
-            )),
-            None => Err(McpError::invalid_params(
-                "Unknown task_id",
-                Some(json!({ "task_id": request.task_id })),
-            )),
-        }
+        request: UpdateTaskParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        let owner = self.task_owner(&context.meta);
+        apply_task_update(&self.task_registry, &owner, &request.task_id)
     }
 
     async fn cancel_task(
         &self,
         request: CancelTaskParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<CancelTaskResult, McpError> {
-        if self.task_registry.cancel(&request.task_id) {
-            let state = self.task_registry.get(&request.task_id).ok_or_else(|| {
-                McpError::internal_error(
-                    format!("Task {} disappeared after cancellation", request.task_id),
-                    None,
-                )
-            })?;
-            Ok(CancelTaskResult::new(task_state_to_mcp(&state)))
-        } else {
-            Err(McpError::invalid_params(
-                "Task not found or not running",
+        context: RequestContext<RoleServer>,
+    ) -> Result<(), McpError> {
+        let owner = self.task_owner(&context.meta);
+        let Some(state) = self.task_registry.get_for_owner(&owner, &request.task_id) else {
+            return Err(McpError::invalid_params(
+                "Unknown task_id",
                 Some(json!({ "task_id": request.task_id })),
-            ))
+            ));
+        };
+        if state.status == task::TaskStatus::Running {
+            self.task_registry
+                .cancel_for_owner(&owner, &request.task_id);
         }
+        Ok(())
     }
 }
 
@@ -4882,9 +5589,6 @@ impl<S> std::ops::Deref for SanitizedIdaServer<S> {
     }
 }
 
-/// Tools that support task-based invocation (SEP-1686).
-const TASK_CAPABLE_TOOLS: &[&str] = &["open_dsc"];
-
 fn tool_annotations_for(name: &str) -> ToolAnnotations {
     match name {
         "lumina_lookup" => ToolAnnotations::new()
@@ -4917,11 +5621,6 @@ fn tool_annotations_for(name: &str) -> ToolAnnotations {
 
 fn set_tool_metadata(tool: &mut Tool) {
     tool.annotations = Some(tool_annotations_for(&tool.name));
-    if TASK_CAPABLE_TOOLS.contains(&&*tool.name) {
-        tool.execution = Some(
-            rmcp::model::ToolExecution::new().with_task_support(rmcp::model::TaskSupport::Optional),
-        );
-    }
 }
 
 fn apply_tool_metadata(mut tool: Tool) -> Tool {
@@ -5060,18 +5759,13 @@ fn normalize_tool_input_schema(tool: &mut Tool) {
     }
 }
 
-/// Normalize tool input schemas (see [`normalize_schema_value`]) and
-/// annotate task-capable tools with `execution.taskSupport = "optional"`.
+/// Normalize tool input schemas (see [`normalize_schema_value`]) and attach
+/// safety annotations.
 fn normalize_tool_schemas(result: &mut ListToolsResult) {
     for tool in &mut result.tools {
         normalize_tool_input_schema(tool);
         set_tool_metadata(tool);
     }
-}
-
-/// Patch a single tool definition with task support if applicable.
-fn annotate_task_support(tool: Tool) -> Tool {
-    apply_tool_metadata(tool)
 }
 
 /// Error message for a filter-rejected tool/call. Centralized so the
@@ -5085,6 +5779,15 @@ fn disabled_tool_message(name: &str) -> String {
 }
 
 impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        self.inner.supported_protocol_versions()
+    }
+
+    // `discover` is intentionally NOT forwarded to the inner handler: the
+    // trait default builds its result from `self.supported_protocol_versions()`
+    // and `self.get_info()`, so leaving it unoverridden binds those calls to
+    // this sanitizing wrapper instead of bypassing it.
+
     async fn initialize(
         &self,
         params: InitializeRequestParams,
@@ -5112,7 +5815,7 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
         &self,
         params: CallToolRequestParams,
         ctx: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         if self.filter.is_active() && !self.filter.is_enabled(&params.name) {
             return Err(McpError::invalid_params(
                 disabled_tool_message(&params.name),
@@ -5132,53 +5835,31 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
         }
         self.inner.get_tool(name).map(|mut tool| {
             normalize_tool_input_schema(&mut tool);
-            annotate_task_support(tool)
+            apply_tool_metadata(tool)
         })
     }
 
-    async fn enqueue_task(
-        &self,
-        request: CallToolRequestParams,
-        ctx: RequestContext<RoleServer>,
-    ) -> Result<CreateTaskResult, McpError> {
-        if self.filter.is_active() && !self.filter.is_enabled(&request.name) {
-            return Err(McpError::invalid_params(
-                disabled_tool_message(&request.name),
-                None,
-            ));
-        }
-        self.inner.enqueue_task(request, ctx).await
-    }
-
-    async fn list_tasks(
-        &self,
-        request: Option<PaginatedRequestParams>,
-        ctx: RequestContext<RoleServer>,
-    ) -> Result<ListTasksResult, McpError> {
-        self.inner.list_tasks(request, ctx).await
-    }
-
-    async fn get_task_info(
+    async fn get_task(
         &self,
         request: GetTaskParams,
         ctx: RequestContext<RoleServer>,
     ) -> Result<GetTaskResult, McpError> {
-        self.inner.get_task_info(request, ctx).await
+        self.inner.get_task(request, ctx).await
     }
 
-    async fn get_task_result(
+    async fn update_task(
         &self,
-        request: GetTaskPayloadParams,
+        request: UpdateTaskParams,
         ctx: RequestContext<RoleServer>,
-    ) -> Result<GetTaskPayloadResult, McpError> {
-        self.inner.get_task_result(request, ctx).await
+    ) -> Result<(), McpError> {
+        self.inner.update_task(request, ctx).await
     }
 
     async fn cancel_task(
         &self,
         request: CancelTaskParams,
         ctx: RequestContext<RoleServer>,
-    ) -> Result<CancelTaskResult, McpError> {
+    ) -> Result<(), McpError> {
         self.inner.cancel_task(request, ctx).await
     }
 }
@@ -5186,20 +5867,88 @@ impl<S: ServerHandler + Send + Sync> ServerHandler for SanitizedIdaServer<S> {
 #[cfg(test)]
 mod tests {
     use crate::error::ToolError;
-    use crate::ida::worker::CloseTokenGrant;
+    use crate::ida::worker::{CloseTokenGrant, WorkerBackend};
     use crate::server::{
-        apply_close_metadata, close_hint_for, dsc_open_plan, normalize_schema_value,
+        apply_close_metadata, apply_task_update, call_tool_result_to_value, close_hint_for,
+        dsc_open_plan, is_sessionless_request_meta, materialize_task_response,
+        normalize_schema_value,
         operation::{OperationSnapshot, OperationStatus},
         run_script_failure_message, run_script_succeeded, run_script_timeout_message,
-        run_script_truncate_chars, task_payload_result_value, timeout_with_child_grace,
-        tool_params_schema, DscOpenPlan, IdaMcpServer, RecentOperationsRequest, ToolCatalogRequest,
-        ToolHelpRequest, XrefsRequest,
+        run_script_truncate_chars, supported_protocol_versions, task, task_payload_result_value,
+        task_state_to_detailed_task, task_state_to_mcp_task, timeout_with_child_grace,
+        tool_params_schema, DscOpenPlan, IdaMcpServer, OpenIdbBackgroundDecision,
+        RecentOperationsRequest, ServerRuntimeState, ToolCatalogRequest, ToolHelpRequest,
+        XrefsRequest,
     };
     use rmcp::handler::server::wrapper::Parameters;
-    use rmcp::model::CallToolResult;
+    use rmcp::model::{CallToolResponse, CallToolResult, InputResponses, ProtocolVersion};
+    use rmcp::ServerHandler;
     use serde_json::{json, Value};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{mpsc, Arc};
+
+    const TASK_OWNER: task::TaskOwner = task::TaskOwner::Runtime;
+
+    /// In-memory writer so a test can assert on exactly what the fmt layer
+    /// would have written to stderr, span field prefixes included.
+    #[derive(Clone, Default)]
+    struct CapturedLog(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl CapturedLog {
+        fn text(&self) -> String {
+            let guard = self
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            String::from_utf8_lossy(&guard).into_owned()
+        }
+    }
+
+    impl std::io::Write for CapturedLog {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut guard = self
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            guard.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLog {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `body` with a thread-local subscriber at `directives` and return
+    /// everything it logged. `set_default` keeps this off the global
+    /// dispatcher, so tests stay independent.
+    async fn capture_logs<F, Fut>(directives: &str, body: F) -> String
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        use tracing_subscriber::layer::SubscriberExt as _;
+        use tracing_subscriber::Layer as _;
+
+        let captured = CapturedLog::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(captured.clone())
+                .with_filter(tracing_subscriber::EnvFilter::new(directives)),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+        body().await;
+        captured.text()
+    }
 
     fn test_server() -> IdaMcpServer {
         let (tx, _rx) = mpsc::sync_channel(1);
@@ -5207,6 +5956,231 @@ mod tests {
             Arc::new(crate::IdaWorker::new(tx)),
             crate::ServerMode::Stdio,
         )
+    }
+
+    /// Sentinels chosen so a substring hit can only come from the payload we
+    /// passed in, never from incidental log text.
+    const SECRET_CLOSE_TOKEN: &str = "close-token-9d41f2c7";
+    const SECRET_COMMENT: &str = "comment-secret-3a7f11de";
+    const SECRET_RENAME: &str = "rename-secret-5c2b90aa";
+    const SECRET_PATCH_BYTES: &str = "de ad be ef ca fe 41 42";
+
+    /// Drive every unit-invocable handler that receives sensitive payloads.
+    /// Each call fails fast (the test worker has no receiver), which is
+    /// exactly the path that logs — spans render whenever an event fires
+    /// inside them.
+    async fn exercise_sensitive_handlers(server: &IdaMcpServer) {
+        let _ = server
+            .close_idb(Parameters(crate::server::CloseIdbRequest {
+                token: Some(SECRET_CLOSE_TOKEN.to_string()),
+                force: Some(false),
+            }))
+            .await;
+        let _ = server
+            .set_comments(Parameters(crate::server::SetCommentsRequest {
+                address: Some(json!("0x1000")),
+                target_name: None,
+                offset: None,
+                comment: SECRET_COMMENT.to_string(),
+                repeatable: None,
+            }))
+            .await;
+        let _ = server
+            .rename(Parameters(crate::server::RenameRequest {
+                address: Some(json!("0x1000")),
+                current_name: None,
+                name: SECRET_RENAME.to_string(),
+                flags: None,
+            }))
+            .await;
+        let _ = server
+            .patch(Parameters(crate::server::PatchRequest {
+                address: Some(json!("0x1000")),
+                target_name: None,
+                offset: None,
+                bytes: json!(SECRET_PATCH_BYTES),
+            }))
+            .await;
+    }
+
+    fn assert_no_secrets(logs: &str, level: &str) {
+        for (label, secret) in [
+            ("close_idb ownership token", SECRET_CLOSE_TOKEN),
+            ("set_comments payload", SECRET_COMMENT),
+            ("rename payload", SECRET_RENAME),
+            ("patch bytes", SECRET_PATCH_BYTES),
+        ] {
+            assert!(
+                !logs.contains(secret),
+                "{label} leaked into logs at {level}:\n{logs}"
+            );
+        }
+        // The whole-struct render is the mechanism behind every leak; catching
+        // it directly means a future handler cannot regress quietly.
+        for struct_render in [
+            "CloseIdbRequest {",
+            "SetCommentsRequest {",
+            "RenameRequest {",
+            "PatchRequest {",
+            "req=",
+        ] {
+            assert!(
+                !logs.contains(struct_render),
+                "a handler argument was recorded ({struct_render}) at {level}:\n{logs}"
+            );
+        }
+    }
+
+    /// The shipped default is `ida_mcp=info`, and `close_idb` logs at INFO
+    /// unconditionally — so before this fix the ownership bearer token
+    /// rendered on an out-of-the-box server, not just under trace logging.
+    #[tokio::test]
+    async fn spans_never_record_secret_payloads_at_the_shipped_level() {
+        let server = test_server();
+        let logs = capture_logs("ida_mcp=info", || async {
+            exercise_sensitive_handlers(&server).await;
+        })
+        .await;
+
+        // Positive control: prove the capture is wired and the level admits
+        // output, so the absence assertions below cannot pass vacuously.
+        assert!(
+            logs.contains("Tool call: close_idb received"),
+            "expected close_idb to log at ida_mcp=info; got:\n{logs}"
+        );
+        assert_no_secrets(&logs, "ida_mcp=info");
+        assert!(
+            logs.contains("has_token=true"),
+            "expected the sanitized has_token field; got:\n{logs}"
+        );
+    }
+
+    /// Strictly stronger than the shipped level, and the level `just test-*`
+    /// recipes run at: nothing sensitive may appear even at trace.
+    #[tokio::test]
+    async fn spans_never_record_secret_payloads_at_trace() {
+        let server = test_server();
+        let logs = capture_logs("ida_mcp=trace", || async {
+            exercise_sensitive_handlers(&server).await;
+        })
+        .await;
+
+        assert!(
+            logs.contains("Tool call: close_idb received"),
+            "expected handler events at trace; got:\n{logs}"
+        );
+        assert_no_secrets(&logs, "ida_mcp=trace");
+    }
+
+    /// Reassemble every `#[instrument(...)]` attribute in a source file,
+    /// joining continuation lines by paren balance.
+    fn instrument_attributes(source: &str) -> Vec<String> {
+        let mut attributes = Vec::new();
+        let mut current: Option<(String, i32)> = None;
+        for line in source.lines() {
+            let trimmed = line.trim();
+            let start = current.is_none() && trimmed.starts_with("#[instrument");
+            if start || current.is_some() {
+                let (mut text, mut depth) = current.take().unwrap_or_default();
+                text.push_str(trimmed);
+                depth += i32::try_from(trimmed.matches('(').count()).unwrap_or(0);
+                depth -= i32::try_from(trimmed.matches(')').count()).unwrap_or(0);
+                if depth <= 0 {
+                    attributes.push(text);
+                } else {
+                    current = Some((text, depth));
+                }
+            }
+        }
+        attributes
+    }
+
+    /// `skip_all` is the only form that suppresses handler arguments:
+    /// tracing-attributes records every parameter binding via `Debug`, and a
+    /// `fields(...)` entry only suppresses a parameter whose ident exactly
+    /// matches the field name — so `fields(path = %req.path)` still records
+    /// the whole `req`. This is the only coverage for handlers that take a
+    /// `RequestContext` (`open_idb`, `run_script`) since `Peer`'s constructor
+    /// is `pub(crate)` and they cannot be invoked from a unit test.
+    #[test]
+    fn instrument_attributes_never_capture_handler_arguments() {
+        for (path, source) in [
+            ("src/server/mod.rs", include_str!("mod.rs")),
+            ("src/server/task.rs", include_str!("task.rs")),
+            ("src/server/http_config.rs", include_str!("http_config.rs")),
+        ] {
+            let attributes = instrument_attributes(source);
+            for attribute in &attributes {
+                assert!(
+                    attribute.contains("skip_all"),
+                    "{path}: `{attribute}` must use skip_all; \
+                     skip(self) still records every request argument"
+                );
+            }
+            if path == "src/server/mod.rs" {
+                assert!(
+                    attributes.len() >= 50,
+                    "expected the full handler set in {path}, found {}",
+                    attributes.len()
+                );
+            }
+        }
+    }
+
+    /// The two handlers that cannot be exercised at runtime must expose only
+    /// derived facts, never the sensitive binding itself.
+    #[test]
+    fn uninvokable_handlers_record_only_derived_fields() {
+        let attributes = instrument_attributes(include_str!("mod.rs"));
+
+        let open_idb = attributes
+            .iter()
+            .find(|attribute| attribute.contains("mrtr_retry"))
+            .expect("open_idb should record whether this is an MRTR retry");
+        // A bool derived from the sealed state, never the replayable handle
+        // or the raw elicitation answers.
+        assert!(open_idb.contains("request_state.is_some()"), "{open_idb}");
+        assert!(!open_idb.contains("%request_state"), "{open_idb}");
+        assert!(!open_idb.contains("?request_state"), "{open_idb}");
+        assert!(!open_idb.contains("input_responses"), "{open_idb}");
+
+        let run_script = attributes
+            .iter()
+            .find(|attribute| attribute.contains("code_len"))
+            .expect("run_script should record only the source length");
+        assert!(!run_script.contains("%req.code"), "{run_script}");
+        assert!(!run_script.contains("?req.code"), "{run_script}");
+    }
+
+    #[test]
+    fn tracing_never_records_task_bearer_ids() {
+        let bearer_field = ["task", "id"].join("_");
+        for (path, source) in [
+            ("src/server/mod.rs", include_str!("mod.rs")),
+            ("src/server/task.rs", include_str!("task.rs")),
+        ] {
+            for formatter in ['%', '?'] {
+                let forbidden = format!("{bearer_field} = {formatter}");
+                assert!(
+                    !source.contains(&forbidden),
+                    "{path}: task bearer IDs must not be recorded by tracing: found `{forbidden}`"
+                );
+            }
+            for level in ["trace", "debug", "info", "warn", "error"] {
+                let forbidden = format!("{level}!({bearer_field}");
+                assert!(
+                    !source.contains(&forbidden),
+                    "{path}: task bearer IDs must not be recorded by tracing: found `{forbidden}`"
+                );
+            }
+
+            for attribute in instrument_attributes(source) {
+                assert!(
+                    !attribute.contains(&bearer_field),
+                    "{path}: task bearer IDs must not be recorded by instrumentation: `{attribute}`"
+                );
+            }
+        }
     }
 
     fn xrefs_request(limit: Option<i64>, offset: Option<i64>) -> XrefsRequest {
@@ -5270,13 +6244,36 @@ mod tests {
         );
     }
 
+    /// An existing database wins on every SDK: it preserves prior analysis
+    /// and, on 9.4, prevents the direct path from minting a fresh multi-GB
+    /// database per open_dsc call.
     #[test]
-    fn dsc_open_plan_prefers_existing_i64_before_ida_94() {
+    fn dsc_open_plan_prefers_existing_i64_on_every_sdk() {
         assert_eq!(dsc_open_plan((9, 3), true), DscOpenPlan::DirectExistingI64);
-        assert_eq!(
-            dsc_open_plan((9, 4), true),
-            DscOpenPlan::BackgroundDirectRawDsc
-        );
+        assert_eq!(dsc_open_plan((9, 4), true), DscOpenPlan::DirectExistingI64);
+        assert_eq!(dsc_open_plan((10, 0), true), DscOpenPlan::DirectExistingI64);
+    }
+
+    /// The direct-path database name must depend only on the DSC's absolute
+    /// path — never pid or time — so repeat opens resolve to one reusable
+    /// file instead of accumulating orphans.
+    #[test]
+    fn direct_dsc_cache_path_is_deterministic_per_dsc() {
+        let dsc = std::path::Path::new("/nonexistent/A/dyld_shared_cache_arm64e");
+        let first = crate::server::direct_dsc_cache_i64_path(dsc);
+        let second = crate::server::direct_dsc_cache_i64_path(dsc);
+        let other = crate::server::direct_dsc_cache_i64_path(std::path::Path::new(
+            "/nonexistent/B/dyld_shared_cache_arm64e",
+        ));
+
+        assert_eq!(first, second);
+        assert_ne!(first, other, "different DSC paths must not collide");
+        let name = first
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("cache path should have a printable file name");
+        assert!(name.starts_with("ida-mcp-dsc-dyld_shared_cache_arm64e-"));
+        assert!(name.ends_with(".i64"));
     }
 
     fn tool_result_text(result: CallToolResult) -> String {
@@ -5647,6 +6644,429 @@ mod tests {
             .map(|t| t.text.as_str())
             .unwrap_or_default();
         assert!(wrapped_text.contains("\"content\""));
+    }
+
+    #[test]
+    fn modern_protocol_is_excluded_from_pooled_workers() {
+        let local = supported_protocol_versions(false);
+        assert!(local.contains(&ProtocolVersion::V_2026_07_28));
+
+        let pooled = supported_protocol_versions(true);
+        assert!(!pooled.contains(&ProtocolVersion::V_2026_07_28));
+        assert!(pooled.contains(&ProtocolVersion::V_2025_11_25));
+    }
+
+    #[test]
+    fn server_advertises_tasks_extension() {
+        assert!(ServerHandler::get_info(&test_server())
+            .capabilities
+            .supports_tasks());
+    }
+
+    #[test]
+    fn task_seed_uses_retention_ttl_and_poll_interval() {
+        let registry = crate::server::task::TaskRegistry::new();
+        let id = registry
+            .create_keyed(&TASK_OWNER, "test", "seed", "Working")
+            .expect("create task");
+        let state = registry.get(&id).expect("task state");
+        let value = serde_json::to_value(task_state_to_mcp_task(&state)).expect("serialize task");
+
+        assert_eq!(value["status"], "working");
+        assert_eq!(value["ttlMs"], task::TASK_RETENTION_TTL_MS);
+        assert_eq!(value["pollIntervalMs"], 5000);
+    }
+
+    #[test]
+    fn completed_task_inlines_original_tool_result() {
+        let registry = crate::server::task::TaskRegistry::new();
+        let tool_result = CallToolResult::success(vec![rmcp::model::ContentBlock::text("done")]);
+        let payload = serde_json::to_value(tool_result).expect("serialize tool result");
+        let id = registry
+            .create_completed(&TASK_OWNER, "Completed", payload)
+            .expect("create completed task");
+        let state = registry.get(&id).expect("task state");
+        let value =
+            serde_json::to_value(task_state_to_detailed_task(state)).expect("serialize task");
+
+        assert_eq!(value["status"], "completed");
+        assert_eq!(value["result"]["content"][0]["text"], "done");
+        assert_eq!(value["result"]["isError"], false);
+    }
+
+    #[test]
+    fn tool_error_is_a_completed_task_result_not_a_json_rpc_failure() {
+        let registry = crate::server::task::TaskRegistry::new();
+        let id = registry
+            .create_keyed(&TASK_OWNER, "dsc", "tool-error", "Opening DSC")
+            .expect("create task");
+        let error_result =
+            ToolError::OpenFailed("idat exited with code 4".to_string()).to_tool_result();
+        registry.complete(&id, call_tool_result_to_value(&error_result));
+
+        let state = registry.get(&id).expect("task state");
+        let value =
+            serde_json::to_value(task_state_to_detailed_task(state)).expect("serialize task");
+
+        assert_eq!(value["status"], "completed");
+        assert_eq!(value["result"]["isError"], true);
+        assert!(value["result"]["content"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("idat exited with code 4")));
+        assert!(value.get("error").is_none());
+    }
+
+    #[test]
+    fn open_dsc_background_result_materializes_tasks_extension_handle() {
+        let registry = crate::server::task::TaskRegistry::new();
+        let task_id = registry
+            .create_keyed(&TASK_OWNER, "dsc", "/tmp/cache", "Opening DSC")
+            .expect("create task");
+        let result = CallToolResult::success(vec![rmcp::model::ContentBlock::text(
+            serde_json::to_string(&json!({"task_id": task_id})).expect("serialize result"),
+        )]);
+        let response =
+            materialize_task_response(&registry, true, CallToolResponse::Complete(result))
+                .expect("materialize task");
+
+        let CallToolResponse::Task(created) = response else {
+            panic!("task-capable open_dsc call must return a task handle");
+        };
+        assert_eq!(created.task.task_id, task_id);
+        assert_eq!(created.task.status, rmcp::model::TaskStatus::Working);
+        assert_eq!(created.task.poll_interval_ms, Some(5000));
+        assert_eq!(created.task.ttl_ms, Some(task::TASK_RETENTION_TTL_MS));
+    }
+
+    #[test]
+    fn update_task_acknowledges_known_tasks_and_rejects_unknown() {
+        let registry = crate::server::task::TaskRegistry::new();
+        let id = registry
+            .create_keyed(&TASK_OWNER, "dsc", "update-task", "Working")
+            .expect("create task");
+
+        // SEP-2663: responses delivered to a known task are ignored with an
+        // empty result, never an error — including after a raced transition
+        // to a terminal state.
+        assert!(apply_task_update(&registry, &TASK_OWNER, &id).is_ok());
+        registry.complete(&id, json!({"ok": true}));
+        assert!(apply_task_update(&registry, &TASK_OWNER, &id).is_ok());
+
+        let other_owner = task::TaskOwner::Session(Arc::from("other-session"));
+        let err = apply_task_update(&registry, &other_owner, &id)
+            .expect_err("another owner must not update the task");
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+
+        let err = apply_task_update(&registry, &TASK_OWNER, "missing-1")
+            .expect_err("unknown task must error");
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn failed_task_inlines_json_rpc_error() {
+        let registry = crate::server::task::TaskRegistry::new();
+        let id = registry
+            .create_keyed(&TASK_OWNER, "test", "failed", "Working")
+            .expect("create task");
+        registry.fail(&id, "IDA worker exited");
+        let state = registry.get(&id).expect("task state");
+        let value =
+            serde_json::to_value(task_state_to_detailed_task(state)).expect("serialize task");
+
+        assert_eq!(value["status"], "failed");
+        assert_eq!(value["error"]["code"], -32603);
+        assert_eq!(value["error"]["message"], "IDA worker exited");
+    }
+
+    #[test]
+    fn runtime_state_survives_handler_recreation() {
+        let (tx, _rx) = mpsc::sync_channel(1);
+        let backend = WorkerBackend::local(Arc::new(crate::IdaWorker::new(tx)));
+        let filter = Arc::new(crate::server::tool_filter::ToolFilter::unrestricted());
+        let runtime = ServerRuntimeState::new();
+        let first = IdaMcpServer::with_filter_and_state(
+            backend.clone(),
+            crate::ServerMode::Http,
+            filter.clone(),
+            runtime.clone(),
+        );
+        let second =
+            IdaMcpServer::with_filter_and_state(backend, crate::ServerMode::Http, filter, runtime);
+        let id = first
+            .task_registry
+            .create_completed(&first.session_task_owner, "Completed", json!({"ok": true}))
+            .expect("create completed task");
+
+        assert!(second.task_registry.get(&id).is_some());
+        assert!(Arc::ptr_eq(
+            &first.runtime_lifetime,
+            &second.runtime_lifetime
+        ));
+        // Each handler owns its own session lifetime so that dropping a legacy
+        // session's handler cancels only that session's background tasks.
+        assert!(!Arc::ptr_eq(
+            &first.session_lifetime,
+            &second.session_lifetime
+        ));
+    }
+
+    #[test]
+    fn shared_runtime_keeps_legacy_task_ownership_session_scoped() {
+        let (tx, _rx) = mpsc::sync_channel(1);
+        let backend = WorkerBackend::local(Arc::new(crate::IdaWorker::new(tx)));
+        let filter = Arc::new(crate::server::tool_filter::ToolFilter::unrestricted());
+        let runtime = ServerRuntimeState::new();
+        let first = IdaMcpServer::with_filter_and_state(
+            backend.clone(),
+            crate::ServerMode::Http,
+            filter.clone(),
+            runtime.clone(),
+        );
+        let second =
+            IdaMcpServer::with_filter_and_state(backend, crate::ServerMode::Http, filter, runtime);
+
+        let task_id = first
+            .task_registry
+            .create_keyed(
+                &first.session_task_owner,
+                "dsc",
+                "/tmp/shared-cache",
+                "Opening DSC",
+            )
+            .expect("first session should create the task");
+        assert_eq!(
+            second.task_registry.create_keyed(
+                &second.session_task_owner,
+                "dsc",
+                "/tmp/shared-cache",
+                "Opening DSC",
+            ),
+            Err(task::TaskCreateError::ExistingTaskIdIsPrivate)
+        );
+        assert!(
+            second
+                .task_registry
+                .get_for_owner(&second.session_task_owner, &task_id)
+                .is_none(),
+            "another legacy session must not poll the task"
+        );
+        assert!(!second
+            .task_registry
+            .cancel_for_owner(&second.session_task_owner, &task_id));
+        assert!(first
+            .task_registry
+            .get_for_owner(&first.session_task_owner, &task_id)
+            .is_some());
+    }
+
+    #[test]
+    fn handler_drop_cancels_session_background_tasks_only() {
+        let (tx, _rx) = mpsc::sync_channel(1);
+        let backend = WorkerBackend::local(Arc::new(crate::IdaWorker::new(tx)));
+        let filter = Arc::new(crate::server::tool_filter::ToolFilter::unrestricted());
+        let runtime = ServerRuntimeState::new();
+        let server = IdaMcpServer::with_filter_and_state(
+            backend,
+            crate::ServerMode::Http,
+            filter,
+            runtime.clone(),
+        );
+
+        let legacy_meta = rmcp::model::RequestMetaObject::new();
+        let mut sessionless_meta = rmcp::model::RequestMetaObject::new();
+        sessionless_meta.set_protocol_version(ProtocolVersion::V_2026_07_28);
+        sessionless_meta.set_client_capabilities(rmcp::model::ClientCapabilities::default());
+
+        let session_token = server.background_lifetime(&legacy_meta).child_token();
+        let runtime_token = server.background_lifetime(&sessionless_meta).child_token();
+        drop(server);
+
+        // Legacy session close (= handler drop) cancels the session's tasks...
+        assert!(session_token.is_cancelled());
+        // ...but sessionless MCP 2026 tasks outlive their per-request handler.
+        assert!(!runtime_token.is_cancelled());
+
+        drop(runtime);
+        assert!(runtime_token.is_cancelled());
+    }
+
+    /// Under `--stateless`, rmcp drops the handler after every request even
+    /// for legacy protocol versions, so legacy requests must also use the
+    /// shared runtime owner and lifetime — otherwise their background tasks
+    /// would be cancelled on response and owned by an unreachable session ID.
+    #[test]
+    fn stateless_http_routes_legacy_requests_to_the_runtime_owner() {
+        let (tx, _rx) = mpsc::sync_channel(1);
+        let backend = WorkerBackend::local(Arc::new(crate::IdaWorker::new(tx)));
+        let filter = Arc::new(crate::server::tool_filter::ToolFilter::unrestricted());
+        let runtime = ServerRuntimeState::new_stateless_http();
+        let server = IdaMcpServer::with_filter_and_state(
+            backend,
+            crate::ServerMode::Http,
+            filter,
+            runtime.clone(),
+        );
+
+        let legacy_meta = rmcp::model::RequestMetaObject::new();
+        assert_eq!(server.task_owner(&legacy_meta), task::TaskOwner::Runtime);
+        let background_token = server.background_lifetime(&legacy_meta).child_token();
+        drop(server);
+        assert!(
+            !background_token.is_cancelled(),
+            "stateless-mode tasks must outlive their per-request handler"
+        );
+
+        drop(runtime);
+        assert!(background_token.is_cancelled());
+    }
+
+    #[test]
+    fn sessionless_meta_predicate_requires_complete_2026_key_set() {
+        let mut meta = rmcp::model::RequestMetaObject::new();
+        assert!(!is_sessionless_request_meta(&meta));
+
+        meta.set_protocol_version(ProtocolVersion::V_2026_07_28);
+        assert!(!is_sessionless_request_meta(&meta));
+
+        meta.set_client_capabilities(rmcp::model::ClientCapabilities::default());
+        assert!(is_sessionless_request_meta(&meta));
+
+        // rmcp routes on key completeness, not the declared version: a legacy
+        // version with the full key set still dispatches sessionless.
+        let mut legacy_declared = rmcp::model::RequestMetaObject::new();
+        legacy_declared.set_protocol_version(ProtocolVersion::V_2025_11_25);
+        legacy_declared.set_client_capabilities(rmcp::model::ClientCapabilities::default());
+        assert!(is_sessionless_request_meta(&legacy_declared));
+    }
+
+    #[test]
+    fn legacy_stdio_task_owner_stays_stable_when_request_metadata_changes() {
+        let server = test_server();
+        let mut full_meta = rmcp::model::RequestMetaObject::new();
+        full_meta.set_protocol_version(ProtocolVersion::V_2025_11_25);
+        full_meta.set_client_capabilities(rmcp::model::ClientCapabilities::default());
+        let empty_meta = rmcp::model::RequestMetaObject::new();
+
+        let task_id = server
+            .task_registry
+            .create_keyed(
+                &server.task_owner(&full_meta),
+                "analyze",
+                "stdio-owner-regression",
+                "Working",
+            )
+            .expect("full-metadata request should create a task");
+
+        assert!(
+            server
+                .task_registry
+                .get_for_owner(&server.task_owner(&empty_meta), &task_id)
+                .is_some(),
+            "later requests on the same stdio connection must retain ownership"
+        );
+        assert!(std::ptr::eq(
+            server.background_lifetime(&full_meta),
+            server.background_lifetime(&empty_meta)
+        ));
+    }
+
+    #[test]
+    fn modern_open_idb_mrtr_is_bound_and_integrity_checked() {
+        let server = test_server();
+        let path = "/tmp/large-macho";
+        let size = crate::server::OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES + 1;
+        let first = server
+            .modern_open_idb_background_decision(path, size, None, None)
+            .expect("first MRTR round");
+        let OpenIdbBackgroundDecision::InputRequired(input_required) = first else {
+            panic!("first round must request input");
+        };
+        let request_state = input_required.request_state.expect("request state");
+        let requests = input_required.input_requests.expect("input requests");
+        let request = requests.get("background").expect("background request");
+        let request_value = serde_json::to_value(request).expect("serialize request");
+        assert_eq!(
+            request_value["params"]["requestedSchema"]["properties"]["background"]["type"],
+            "boolean"
+        );
+
+        let mut responses = InputResponses::new();
+        responses.insert(
+            "background".to_string(),
+            json!({"action": "accept", "content": {"background": true}}),
+        );
+        let retry = server
+            .modern_open_idb_background_decision(
+                path,
+                size,
+                Some(request_state.clone()),
+                Some(responses),
+            )
+            .expect("valid retry");
+        assert!(matches!(retry, OpenIdbBackgroundDecision::Ready(true)));
+
+        assert!(server
+            .modern_open_idb_background_decision(
+                "/tmp/different-macho",
+                size,
+                Some(request_state.clone()),
+                Some(InputResponses::new()),
+            )
+            .is_err());
+        assert!(server
+            .modern_open_idb_background_decision(
+                path,
+                size,
+                Some(format!("{request_state}tampered")),
+                Some(InputResponses::new()),
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn modern_open_idb_mrtr_decline_keeps_foreground_behavior() {
+        let server = test_server();
+        let path = "/tmp/large-macho";
+        let size = crate::server::OPEN_IDB_AUTO_BACKGROUND_THRESHOLD_BYTES + 1;
+        let first = server
+            .modern_open_idb_background_decision(path, size, None, None)
+            .expect("first MRTR round");
+        let OpenIdbBackgroundDecision::InputRequired(input_required) = first else {
+            panic!("first round must request input");
+        };
+        let mut responses = InputResponses::new();
+        responses.insert("background".to_string(), json!({"action": "decline"}));
+        let retry = server
+            .modern_open_idb_background_decision(
+                path,
+                size,
+                input_required.request_state,
+                Some(responses),
+            )
+            .expect("valid decline");
+
+        assert!(matches!(retry, OpenIdbBackgroundDecision::Ready(false)));
+    }
+
+    /// A killed idat leaves partial artifacts that `dsc_open_plan` would
+    /// otherwise reuse; cancellation cleanup must remove exactly those.
+    #[test]
+    fn remove_partial_idat_outputs_deletes_packed_and_unpacked_artifacts() {
+        let dir = std::env::temp_dir().join(format!("ida-mcp-partial-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let out_i64 = dir.join("cache.i64");
+        let unpacked = dir.join("cache.id0");
+        let unrelated = dir.join("keep.txt");
+        std::fs::write(&out_i64, b"partial").expect("write i64");
+        std::fs::write(&unpacked, b"partial").expect("write id0");
+        std::fs::write(&unrelated, b"keep").expect("write unrelated");
+
+        crate::server::remove_partial_idat_outputs(&out_i64);
+
+        assert!(!out_i64.exists(), "packed database must be removed");
+        assert!(!unpacked.exists(), "unpacked component must be removed");
+        assert!(unrelated.exists(), "unrelated files must be untouched");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn create_sparse_test_file(name: &str, len: u64) -> std::io::Result<std::path::PathBuf> {

--- a/src/server/requests.rs
+++ b/src/server/requests.rs
@@ -122,11 +122,13 @@ mod tests {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CloseIdbRequest {
-    #[schemars(description = "Ownership token returned by open_idb (required for HTTP/SSE).")]
+    #[schemars(
+        description = "Ownership token returned by open_idb. Required when an HTTP/SSE request is not in the owning legacy session; sessionless MCP 2026 clients should provide it unless force=true is used for trusted recovery."
+    )]
     #[serde(alias = "close_token", alias = "owner_token")]
     pub token: Option<String>,
     #[schemars(
-        description = "Force-close the database even if the original HTTP owner session or token was lost. Use only for recovery."
+        description = "Force-close the database when the original HTTP close token was lost. Use only from a trusted client for recovery."
     )]
     #[serde(alias = "recover", alias = "override_owner")]
     pub force: Option<bool>,

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -2,28 +2,77 @@
 //!
 //! Serves two consumers:
 //! - The custom `task_status` MCP tool (universal fallback for all clients)
-//! - The native MCP Tasks protocol (SEP-1686) via `ServerHandler` methods
+//! - The native MCP Tasks extension (SEP-2663) via `ServerHandler` methods
 
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-pub const TERMINAL_TASK_CAP: usize = 256;
-/// `ttl` value exposed via MCP task metadata.
-/// `0` communicates there is no minimum retention guarantee.
-pub const TASK_RETENTION_TTL_MS: u64 = 0;
+/// Protocol TTL advertised from task creation (SEP-2663 `ttlMs`). Terminal
+/// entries are pruned this long after their last transition; running tasks are
+/// never pruned. A result normally outlives completion by the full TTL, but is
+/// reclaimed earlier if it is the oldest terminal entry when the registry hits
+/// [`MAX_TASK_REGISTRY_ENTRIES`].
+pub const TASK_RETENTION_TTL_MS: u64 = 24 * 60 * 60 * 1000;
+
+/// Hard bound for all retained tasks, including running tasks.
+///
+/// Terminal entries normally remain available for the full advertised TTL, but
+/// admission takes priority over retention: reaching this bound reclaims the
+/// least recently updated terminal entries rather than rejecting new work, so
+/// a run of completed tasks cannot strand background work for the whole TTL.
+/// New work is rejected only when every slot is held by a running task.
+pub const MAX_TASK_REGISTRY_ENTRIES: usize = 256;
+
+/// Identity allowed to observe and control a task.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskOwner {
+    /// A stateful legacy HTTP/SSE or stdio MCP session.
+    Session(Arc<str>),
+    /// Sessionless MCP 2026 requests, which have no stable session identity.
+    Runtime,
+}
+
+/// Failure to admit a background task.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskCreateError {
+    /// The same legacy session already has matching work in progress.
+    AlreadyRunning(String),
+    /// Matching work exists, but its bearer task ID must remain private.
+    ExistingTaskIdIsPrivate,
+    /// Every slot in the bounded registry is held by a running task, so there
+    /// is nothing reclaimable to make room for another.
+    CapacityExceeded { max_entries: usize },
+}
 
 /// Task status in its lifecycle.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskStatus {
     Running,
     Completed,
     Failed,
     Cancelled,
+}
+
+/// Result of attempting to settle a task after its operation returned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskSettlement {
+    Completed,
+    Failed,
+    Cancelled,
+    Unchanged,
+}
+
+/// Atomic decision made at the final successful-result boundary. A pending
+/// cancellation remains non-terminal so the caller can clean up resources
+/// before publishing `cancelled`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskCompletionDecision {
+    Completed,
+    CancellationPending,
+    Unchanged,
 }
 
 /// Snapshot of a background task's state (cloneable, no handles).
@@ -43,44 +92,48 @@ pub struct TaskState {
     pub key: Option<String>,
 }
 
-/// Internal entry that owns the abort handle.
+/// Internal entry that owns a task's cancellation token.
+///
+/// Deliberately does not retain the spawned `JoinHandle`: aborting it cannot
+/// interrupt an operation blocked in a native IDA call, since a tokio abort
+/// only lands at an await point. Cancellation is cooperative, via the token.
 struct TaskEntry {
+    owner: TaskOwner,
     state: TaskState,
-    handle: Option<JoinHandle<()>>,
     cancel_token: Option<CancellationToken>,
+    cancel_requested: Option<String>,
 }
 
 impl TaskEntry {
-    fn new(state: TaskState) -> Self {
+    fn new(owner: TaskOwner, state: TaskState) -> Self {
         Self {
+            owner,
             state,
-            handle: None,
             cancel_token: None,
+            cancel_requested: None,
         }
     }
 
-    fn set_handle(&mut self, handle: JoinHandle<()>, cancel_token: Option<CancellationToken>) {
-        self.handle = Some(handle);
+    fn set_cancel_token(&mut self, cancel_token: Option<CancellationToken>) {
+        if self.cancel_requested.is_some()
+            && let Some(cancel_token) = cancel_token.as_ref()
+        {
+            cancel_token.cancel();
+        }
         self.cancel_token = cancel_token;
     }
 
     fn clear_runtime(&mut self) {
-        self.handle = None;
         self.cancel_token = None;
     }
 
-    fn abort_runtime(&mut self) {
-        if let Some(cancel_token) = self.cancel_token.take() {
-            cancel_token.cancel();
-        }
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-        }
-    }
-
-    fn complete(&mut self, result: Value) -> bool {
+    fn complete(&mut self, result: Value) -> TaskSettlement {
         if self.state.status != TaskStatus::Running {
-            return false;
+            return TaskSettlement::Unchanged;
+        }
+        if let Some(message) = self.cancel_requested.take() {
+            self.transition_cancelled(&message);
+            return TaskSettlement::Cancelled;
         }
 
         self.state.status = TaskStatus::Completed;
@@ -88,31 +141,58 @@ impl TaskEntry {
         self.state.result = Some(result);
         refresh_updated(&mut self.state);
         self.clear_runtime();
-        true
+        TaskSettlement::Completed
     }
 
-    fn fail(&mut self, error: &str) -> bool {
+    fn fail(&mut self, error: &str) -> TaskSettlement {
         if self.state.status != TaskStatus::Running {
-            return false;
+            return TaskSettlement::Unchanged;
+        }
+        if let Some(message) = self.cancel_requested.take() {
+            self.transition_cancelled(&message);
+            return TaskSettlement::Cancelled;
         }
 
         self.state.status = TaskStatus::Failed;
         self.state.message = error.to_string();
         refresh_updated(&mut self.state);
         self.clear_runtime();
-        true
+        TaskSettlement::Failed
     }
 
-    fn mark_cancelled(&mut self, message: &str) -> bool {
+    fn fail_after_cleanup_error(&mut self, error: &str) -> TaskSettlement {
         if self.state.status != TaskStatus::Running {
+            return TaskSettlement::Unchanged;
+        }
+
+        self.cancel_requested = None;
+        self.state.status = TaskStatus::Failed;
+        self.state.message = error.to_string();
+        refresh_updated(&mut self.state);
+        self.clear_runtime();
+        TaskSettlement::Failed
+    }
+
+    fn request_cancel(&mut self, message: &str) -> bool {
+        if self.state.status != TaskStatus::Running || self.cancel_requested.is_some() {
             return false;
         }
 
-        self.abort_runtime();
+        if let Some(cancel_token) = self.cancel_token.as_ref() {
+            cancel_token.cancel();
+        }
+        self.cancel_requested = Some(message.to_string());
+        self.state.message = format!("{message}; waiting for the operation to settle");
+        refresh_updated(&mut self.state);
+        true
+    }
+
+    fn transition_cancelled(&mut self, message: &str) {
+        self.clear_runtime();
+        self.cancel_requested = None;
         self.state.status = TaskStatus::Cancelled;
         self.state.message = message.to_string();
         refresh_updated(&mut self.state);
-        true
     }
 
     fn finish_cancelled(&mut self, message: &str) -> bool {
@@ -120,26 +200,22 @@ impl TaskEntry {
             return false;
         }
 
-        self.clear_runtime();
-        self.state.status = TaskStatus::Cancelled;
-        self.state.message = message.to_string();
-        refresh_updated(&mut self.state);
+        self.transition_cancelled(message);
         true
+    }
+
+    fn update_message(&mut self, message: &str) {
+        if self.state.status == TaskStatus::Running && self.cancel_requested.is_none() {
+            self.state.message = message.to_string();
+            refresh_updated(&mut self.state);
+        }
     }
 }
 
 /// Thread-safe registry of background tasks.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct TaskRegistry {
     inner: Arc<Mutex<HashMap<String, TaskEntry>>>,
-}
-
-impl Default for TaskRegistry {
-    fn default() -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
 }
 
 impl TaskRegistry {
@@ -147,20 +223,37 @@ impl TaskRegistry {
         Self::default()
     }
 
-    /// Create a task with a deduplication key. If a running task with
-    /// the same key already exists, returns `Err(existing_task_id)`.
-    /// `prefix` is used in the generated task id (e.g. "dsc-1", "analyze-1").
-    pub fn create_keyed(&self, prefix: &str, key: &str, message: &str) -> Result<String, String> {
+    /// Create a task with a deduplication key. A legacy session requesting
+    /// matching work that it owns receives the existing task ID. All other
+    /// matches remain private and block duplicate work. In particular,
+    /// sessionless clients share [`TaskOwner::Runtime`], so Runtime matches
+    /// never disclose the existing bearer ID.
+    /// `prefix` is used in the generated task id (e.g. "dsc", "analyze").
+    pub fn create_keyed(
+        &self,
+        owner: &TaskOwner,
+        prefix: &str,
+        key: &str,
+        message: &str,
+    ) -> Result<String, TaskCreateError> {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        prune_terminal_tasks(&mut entries);
 
-        if let Some(existing_id) = entries
-            .values()
-            .find(|entry| {
-                entry.state.status == TaskStatus::Running && entry.state.key.as_deref() == Some(key)
-            })
-            .map(|entry| entry.state.id.clone())
-        {
-            return Err(existing_id);
+        if let Some(existing) = entries.values().find(|entry| {
+            entry.state.status == TaskStatus::Running && entry.state.key.as_deref() == Some(key)
+        }) {
+            return if matches!(owner, TaskOwner::Session(_)) && &existing.owner == owner {
+                Err(TaskCreateError::AlreadyRunning(existing.state.id.clone()))
+            } else {
+                Err(TaskCreateError::ExistingTaskIdIsPrivate)
+            };
+        }
+
+        reclaim_capacity_for_admission(&mut entries);
+        if entries.len() >= MAX_TASK_REGISTRY_ENTRIES {
+            return Err(TaskCreateError::CapacityExceeded {
+                max_entries: MAX_TASK_REGISTRY_ENTRIES,
+            });
         }
 
         let id = next_task_id(prefix);
@@ -176,17 +269,27 @@ impl TaskRegistry {
             updated_at_iso: created,
             key: Some(key.to_string()),
         };
-        entries.insert(id.clone(), TaskEntry::new(state));
-        prune_terminal_tasks(&mut entries);
+        entries.insert(id.clone(), TaskEntry::new(owner.clone(), state));
         Ok(id)
     }
 
-    /// Create a completed task with a precomputed result payload.
-    ///
-    /// Used for inline task-mode calls that complete immediately but still
-    /// need to be retrievable via tasks/get and tasks/result.
-    pub fn create_completed(&self, message: &str, result: Value) -> String {
+    /// Test fixture: create a terminal task with a precomputed result payload
+    /// without going through the create/complete lifecycle.
+    #[cfg(test)]
+    pub fn create_completed(
+        &self,
+        owner: &TaskOwner,
+        message: &str,
+        result: Value,
+    ) -> Result<String, TaskCreateError> {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        prune_terminal_tasks(&mut entries);
+        reclaim_capacity_for_admission(&mut entries);
+        if entries.len() >= MAX_TASK_REGISTRY_ENTRIES {
+            return Err(TaskCreateError::CapacityExceeded {
+                max_entries: MAX_TASK_REGISTRY_ENTRIES,
+            });
+        }
         let id = next_task_id("task");
         let (now, created) = now_with_iso();
         let state = TaskState {
@@ -200,41 +303,45 @@ impl TaskRegistry {
             updated_at_iso: created,
             key: None,
         };
-        entries.insert(id.clone(), TaskEntry::new(state));
-        prune_terminal_tasks(&mut entries);
-        id
+        entries.insert(id.clone(), TaskEntry::new(owner.clone(), state));
+        Ok(id)
     }
 
-    /// Store the `JoinHandle` for a task so it can be cancelled.
-    pub fn set_handle(&self, id: &str, handle: JoinHandle<()>) {
+    /// Store the cancellation token for a task.
+    ///
+    /// Cancels immediately when cancellation was requested before the spawned
+    /// operation got far enough to register its token.
+    pub fn set_cancel_token(&self, id: &str, cancel_token: CancellationToken) {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = entries.get_mut(id) {
-            entry.set_handle(handle, None);
-        }
-    }
-
-    /// Store the `JoinHandle` and cancellation token for a task.
-    pub fn set_handle_with_cancel_token(
-        &self,
-        id: &str,
-        handle: JoinHandle<()>,
-        cancel_token: CancellationToken,
-    ) {
-        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(entry) = entries.get_mut(id) {
-            entry.set_handle(handle, Some(cancel_token));
+            entry.set_cancel_token(Some(cancel_token));
         }
     }
 
     /// Get a cloneable snapshot of a task's current state.
     pub fn get(&self, id: &str) -> Option<TaskState> {
-        let entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        prune_terminal_tasks(&mut entries);
         entries.get(id).map(|e| e.state.clone())
     }
 
-    /// List all tasks (snapshots only).
+    /// Get a task only when it belongs to the requesting owner. Unknown and
+    /// unauthorized IDs deliberately have the same result.
+    pub fn get_for_owner(&self, owner: &TaskOwner, id: &str) -> Option<TaskState> {
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        prune_terminal_tasks(&mut entries);
+        entries
+            .get(id)
+            .filter(|entry| &entry.owner == owner)
+            .map(|entry| entry.state.clone())
+    }
+
+    /// Test fixture: list all tasks (snapshots only). Production code resolves
+    /// tasks by ID; SEP-2663 dropped `tasks/list`.
+    #[cfg(test)]
     pub fn list_all(&self) -> Vec<TaskState> {
-        let entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        prune_terminal_tasks(&mut entries);
         entries.values().map(|e| e.state.clone()).collect()
     }
 
@@ -242,47 +349,116 @@ impl TaskRegistry {
     pub fn update_message(&self, id: &str, message: &str) {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(entry) = entries.get_mut(id) {
-            entry.state.message = message.to_string();
-            refresh_updated(&mut entry.state);
+            entry.update_message(message);
         }
     }
 
     /// Mark a task as completed with a JSON result.
-    pub fn complete(&self, id: &str, result: Value) {
+    pub fn complete(&self, id: &str, result: Value) -> TaskSettlement {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        let completed = match entries.get_mut(id) {
+        let settlement = match entries.get_mut(id) {
             Some(entry) => entry.complete(result),
-            None => false,
+            None => TaskSettlement::Unchanged,
         };
-        if completed {
+        if settlement != TaskSettlement::Unchanged {
             prune_terminal_tasks(&mut entries);
         }
+        settlement
+    }
+
+    /// Settle a successful operation, publishing cancellation instead when
+    /// its lifetime token was cancelled before the registry transition.
+    pub fn complete_with_cancel_token(
+        &self,
+        id: &str,
+        result: Value,
+        cancel_token: &CancellationToken,
+        cancel_message: &str,
+    ) -> TaskSettlement {
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let settlement = match entries.get_mut(id) {
+            Some(entry) if cancel_token.is_cancelled() => {
+                if entry.finish_cancelled(cancel_message) {
+                    TaskSettlement::Cancelled
+                } else {
+                    TaskSettlement::Unchanged
+                }
+            }
+            Some(entry) => entry.complete(result),
+            None => TaskSettlement::Unchanged,
+        };
+        if settlement != TaskSettlement::Unchanged {
+            prune_terminal_tasks(&mut entries);
+        }
+        settlement
+    }
+
+    /// Complete atomically unless cancellation has already won. Unlike
+    /// [`Self::complete_with_cancel_token`], this leaves cancellation pending
+    /// so resource cleanup can finish before a terminal state is visible.
+    pub fn complete_or_defer_cancellation(
+        &self,
+        id: &str,
+        result: Value,
+        cancel_token: &CancellationToken,
+    ) -> TaskCompletionDecision {
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let decision = match entries.get_mut(id) {
+            Some(entry) if entry.state.status != TaskStatus::Running => {
+                TaskCompletionDecision::Unchanged
+            }
+            Some(entry) if cancel_token.is_cancelled() || entry.cancel_requested.is_some() => {
+                TaskCompletionDecision::CancellationPending
+            }
+            Some(entry) => match entry.complete(result) {
+                TaskSettlement::Completed => TaskCompletionDecision::Completed,
+                TaskSettlement::Failed | TaskSettlement::Cancelled | TaskSettlement::Unchanged => {
+                    TaskCompletionDecision::Unchanged
+                }
+            },
+            None => TaskCompletionDecision::Unchanged,
+        };
+        if decision == TaskCompletionDecision::Completed {
+            prune_terminal_tasks(&mut entries);
+        }
+        decision
     }
 
     /// Mark a task as failed with an error message.
-    pub fn fail(&self, id: &str, error: &str) {
+    pub fn fail(&self, id: &str, error: &str) -> TaskSettlement {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        let failed = match entries.get_mut(id) {
+        let settlement = match entries.get_mut(id) {
             Some(entry) => entry.fail(error),
-            None => false,
+            None => TaskSettlement::Unchanged,
         };
-        if failed {
+        if settlement != TaskSettlement::Unchanged {
             prune_terminal_tasks(&mut entries);
         }
+        settlement
     }
 
-    /// Cancel a running task. Returns `true` if the task was running
-    /// and has been aborted.
-    pub fn cancel(&self, id: &str) -> bool {
-        self.cancel_with_message(id, "Cancelled by client")
-    }
-
-    pub fn cancel_with_message(&self, id: &str, message: &str) -> bool {
+    /// Publish a cleanup failure even when cancellation was requested. A task
+    /// must not claim clean cancellation when its owned resource could not be
+    /// closed or proven replaced.
+    pub fn fail_after_cleanup_error(&self, id: &str, error: &str) -> TaskSettlement {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        let cancelled = match entries.get_mut(id) {
-            Some(entry) => entry.mark_cancelled(message),
-            None => false,
+        let settlement = match entries.get_mut(id) {
+            Some(entry) => entry.fail_after_cleanup_error(error),
+            None => TaskSettlement::Unchanged,
         };
+        if settlement != TaskSettlement::Unchanged {
+            prune_terminal_tasks(&mut entries);
+        }
+        settlement
+    }
+
+    /// Request cancellation only when the task belongs to the owner.
+    pub fn cancel_for_owner(&self, owner: &TaskOwner, id: &str) -> bool {
+        let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let cancelled = entries
+            .get_mut(id)
+            .filter(|entry| &entry.owner == owner)
+            .is_some_and(|entry| entry.request_cancel("Cancelled by client"));
         if cancelled {
             prune_terminal_tasks(&mut entries);
         }
@@ -301,12 +477,12 @@ impl TaskRegistry {
         cancelled
     }
 
-    /// Cancel every currently running task. Returns the number of tasks marked
-    /// as cancelled.
+    /// Request cancellation for every running task. Returns the number of new
+    /// cancellation requests; tasks remain running until their work settles.
     pub fn cancel_all_running(&self, message: &str) -> usize {
         let mut entries = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         let cancelled = entries.values_mut().fold(0, |count, entry| {
-            count + usize::from(entry.mark_cancelled(message))
+            count + usize::from(entry.request_cancel(message))
         });
 
         if cancelled > 0 {
@@ -315,6 +491,20 @@ impl TaskRegistry {
 
         cancelled
     }
+}
+
+/// Generate a task ID with a cryptographically random UUIDv4 component.
+///
+/// The ID is a bearer capability, not just a name: sessionless MCP 2026
+/// clients all share [`TaskOwner::Runtime`], so the ID is the only thing
+/// separating one client's task (and its result, which can carry a
+/// `close_token`) from another's. It must be unguessable — a client that
+/// knows its own ID must not be able to derive any other. Full per-task
+/// randomness also keeps IDs from different registries (pooled HTTP
+/// sessions, worker processes) from colliding, so a stale ID fails lookup
+/// instead of resolving to another task.
+fn next_task_id(prefix: &str) -> String {
+    format!("{prefix}-{}", uuid::Uuid::new_v4().simple())
 }
 
 fn now_with_iso() -> (Instant, String) {
@@ -328,32 +518,51 @@ fn refresh_updated(state: &mut TaskState) {
 }
 
 fn prune_terminal_tasks(entries: &mut HashMap<String, TaskEntry>) {
-    let terminal_ids: Vec<_> = entries
-        .iter()
-        .filter_map(|(id, entry)| {
-            (entry.state.status != TaskStatus::Running)
-                .then_some((id.clone(), entry.state.updated_at))
-        })
-        .collect();
+    let retention = std::time::Duration::from_millis(TASK_RETENTION_TTL_MS);
+    let now = Instant::now();
+    // Measure from `updated_at` (refreshed on the terminal transition), not
+    // `created_at`: a task that ran longer than the TTL must stay retrievable
+    // after it completes, not vanish in the same call that stored its result.
+    entries.retain(|_, entry| {
+        entry.state.status == TaskStatus::Running
+            || now.saturating_duration_since(entry.state.updated_at) < retention
+    });
+}
 
-    if terminal_ids.len() <= TERMINAL_TASK_CAP {
+/// Make room for one new task, reclaiming the least recently updated terminal
+/// entries when the registry is at capacity.
+///
+/// The TTL sweep alone lets completed tasks accumulate to the cap well inside
+/// the retention window; admission then fails for every new background task
+/// even though none are running, and stays failed until the oldest entry ages
+/// out. Reclaiming instead means a caller can always make progress while any
+/// entry is still reclaimable.
+///
+/// Deliberately *not* part of [`prune_terminal_tasks`]: that runs on read paths
+/// too (`get`, `list_all`), and a read must never discard a result the caller
+/// did not ask to drop.
+///
+/// Running entries are never reclaimed — they hold their slot legitimately, so
+/// a registry saturated with in-flight work still reports `CapacityExceeded`.
+fn reclaim_capacity_for_admission(entries: &mut HashMap<String, TaskEntry>) {
+    if entries.len() < MAX_TASK_REGISTRY_ENTRIES {
         return;
     }
 
-    let mut ordered = terminal_ids;
-    ordered.sort_by_key(|(_, updated_at)| *updated_at);
-    let remove_count = ordered.len() - TERMINAL_TASK_CAP;
+    let mut terminal = Vec::new();
+    for (id, entry) in entries.iter() {
+        if entry.state.status != TaskStatus::Running {
+            terminal.push((entry.state.updated_at, id.clone()));
+        }
+    }
+    terminal.sort_unstable();
 
-    for (id, _) in ordered.into_iter().take(remove_count) {
+    // Free one slot beyond the cap so the caller that triggered this prune can
+    // be admitted.
+    let excess = entries.len() - MAX_TASK_REGISTRY_ENTRIES + 1;
+    for (_, id) in terminal.into_iter().take(excess) {
         entries.remove(&id);
     }
-}
-
-/// Generate a unique task ID using an atomic counter and prefix.
-fn next_task_id(prefix: &str) -> String {
-    static COUNTER: AtomicU64 = AtomicU64::new(1);
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{prefix}-{n}")
 }
 
 /// ISO-8601 timestamp for the current time (UTC).
@@ -393,16 +602,46 @@ fn epoch_days_to_ymd(days: u64) -> (u64, u64, u64) {
 
 #[cfg(test)]
 mod tests {
-    use crate::server::task::{TaskRegistry, TaskStatus, TERMINAL_TASK_CAP};
+    use crate::server::task::{
+        TaskCompletionDecision, TaskCreateError, TaskOwner, TaskRegistry, TaskSettlement,
+        TaskStatus, MAX_TASK_REGISTRY_ENTRIES, TASK_RETENTION_TTL_MS,
+    };
     use serde_json::json;
-    use std::time::Duration;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
     use tokio_util::sync::CancellationToken;
+
+    const OWNER: TaskOwner = TaskOwner::Runtime;
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Returns `false` when the platform cannot represent an Instant that far
+    /// in the past (Windows Instants start at boot), letting callers skip.
+    fn age_task_past_retention(registry: &TaskRegistry, id: &str) -> bool {
+        let Some(past) =
+            Instant::now().checked_sub(Duration::from_millis(TASK_RETENTION_TTL_MS + 1))
+        else {
+            return false;
+        };
+        let mut entries = registry.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let task = entries.get_mut(id).expect("task should exist before aging");
+        task.state.created_at = past;
+        task.state.updated_at = past;
+        true
+    }
 
     #[test]
     fn create_and_get() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("dsc", "test-key", "Starting")
+            .create_keyed(&OWNER, "dsc", "test-key", "Starting")
             .expect("should succeed");
         assert!(id.starts_with("dsc-"));
         let state = registry.get(&id).expect("task should exist");
@@ -416,7 +655,7 @@ mod tests {
     fn update_message() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "k1", "Phase 1")
+            .create_keyed(&OWNER, "t", "k1", "Phase 1")
             .expect("should succeed");
         registry.update_message(&id, "Phase 2");
         let state = registry.get(&id).expect("task should exist");
@@ -427,10 +666,13 @@ mod tests {
     fn complete_task() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "k2", "Working")
+            .create_keyed(&OWNER, "t", "k2", "Working")
             .expect("should succeed");
         let result = json!({"db": "opened"});
-        registry.complete(&id, result.clone());
+        assert_eq!(
+            registry.complete(&id, result.clone()),
+            TaskSettlement::Completed
+        );
         let state = registry.get(&id).expect("task should exist");
         assert_eq!(state.status, TaskStatus::Completed);
         assert_eq!(state.result, Some(result));
@@ -440,9 +682,12 @@ mod tests {
     fn fail_task() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "k3", "Working")
+            .create_keyed(&OWNER, "t", "k3", "Working")
             .expect("should succeed");
-        registry.fail(&id, "idat exited with code 4");
+        assert_eq!(
+            registry.fail(&id, "idat exited with code 4"),
+            TaskSettlement::Failed
+        );
         let state = registry.get(&id).expect("task should exist");
         assert_eq!(state.status, TaskStatus::Failed);
         assert_eq!(state.message, "idat exited with code 4");
@@ -455,46 +700,150 @@ mod tests {
     }
 
     #[test]
-    fn keyed_dedup_prevents_duplicate() {
+    fn runtime_keyed_dedup_keeps_existing_id_private() {
         let registry = TaskRegistry::new();
         let id1 = registry
-            .create_keyed("dsc", "/path/to/dsc.i64", "First")
+            .create_keyed(&OWNER, "dsc", "/path/to/dsc.i64", "First")
             .expect("first should succeed");
-        let dup = registry.create_keyed("dsc", "/path/to/dsc.i64", "Second");
-        assert_eq!(dup, Err(id1.clone()));
+        let dup = registry.create_keyed(&OWNER, "dsc", "/path/to/dsc.i64", "Second");
+        assert_eq!(dup, Err(TaskCreateError::ExistingTaskIdIsPrivate));
 
         // After completing, a new task with the same key can be created.
         registry.complete(&id1, json!({}));
         let id2 = registry
-            .create_keyed("dsc", "/path/to/dsc.i64", "Third")
+            .create_keyed(&OWNER, "dsc", "/path/to/dsc.i64", "Third")
             .expect("should succeed after first completed");
         assert_ne!(id1, id2);
     }
 
     #[test]
-    fn cancel_running_task() {
+    fn task_ownership_isolates_dedup_lookup_and_cancellation() {
+        let registry = TaskRegistry::new();
+        let owner_a = TaskOwner::Session(Arc::from("session-a"));
+        let owner_b = TaskOwner::Session(Arc::from("session-b"));
+        let id = registry
+            .create_keyed(&owner_a, "dsc", "/path/to/shared.dsc", "Opening")
+            .expect("first owner should create the task");
+
+        assert_eq!(
+            registry.create_keyed(&owner_a, "dsc", "/path/to/shared.dsc", "Opening again"),
+            Err(TaskCreateError::AlreadyRunning(id.clone()))
+        );
+        assert_eq!(
+            registry.create_keyed(&owner_b, "dsc", "/path/to/shared.dsc", "Other owner"),
+            Err(TaskCreateError::ExistingTaskIdIsPrivate)
+        );
+        assert!(registry.get_for_owner(&owner_b, &id).is_none());
+        assert!(!registry.cancel_for_owner(&owner_b, &id));
+        assert_eq!(
+            registry
+                .get_for_owner(&owner_a, &id)
+                .expect("owner should still see its task")
+                .status,
+            TaskStatus::Running
+        );
+
+        registry.complete(&id, json!({"close_token": "owner-a-secret"}));
+        assert!(registry.get_for_owner(&owner_b, &id).is_none());
+        assert_eq!(
+            registry
+                .get_for_owner(&owner_a, &id)
+                .and_then(|task| task.result),
+            Some(json!({"close_token": "owner-a-secret"}))
+        );
+    }
+
+    #[test]
+    fn cancellation_request_remains_running_until_work_settles() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "k4", "Working")
+            .create_keyed(&OWNER, "t", "k4", "Working")
             .expect("should succeed");
-        assert!(registry.cancel(&id));
+        assert!(registry.cancel_for_owner(&OWNER, &id));
         let state = registry.get(&id).expect("task should exist");
-        assert_eq!(state.status, TaskStatus::Cancelled);
+        assert_eq!(state.status, TaskStatus::Running);
+        assert!(state
+            .message
+            .contains("waiting for the operation to settle"));
 
-        // Cancelling again returns false.
-        assert!(!registry.cancel(&id));
+        // A repeated request is acknowledged by the protocol handler but does
+        // not signal the operation twice.
+        assert!(!registry.cancel_for_owner(&OWNER, &id));
+
+        assert_eq!(
+            registry.complete(&id, json!({"late_result": true})),
+            TaskSettlement::Cancelled
+        );
+        let state = registry.get(&id).expect("task should remain retained");
+        assert_eq!(state.status, TaskStatus::Cancelled);
+        assert_eq!(state.message, "Cancelled by client");
+        assert!(state.result.is_none());
+    }
+
+    #[test]
+    fn final_completion_defers_terminal_cancellation_for_cleanup() {
+        let registry = TaskRegistry::new();
+        let id = registry
+            .create_keyed(&OWNER, "dsc", "late-cancel", "Working")
+            .expect("should create task");
+        let cancel_token = CancellationToken::new();
+
+        assert!(registry.cancel_for_owner(&OWNER, &id));
+        assert_eq!(
+            registry.complete_or_defer_cancellation(
+                &id,
+                json!({"close_token": "must-not-publish"}),
+                &cancel_token,
+            ),
+            TaskCompletionDecision::CancellationPending
+        );
+        let pending = registry.get(&id).expect("task should remain visible");
+        assert_eq!(pending.status, TaskStatus::Running);
+        assert!(pending.result.is_none());
+
+        assert!(registry.finish_cancelled(&id, "database closed"));
+        assert_eq!(
+            registry
+                .get(&id)
+                .expect("task should remain retained")
+                .status,
+            TaskStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn cancellation_cleanup_failure_is_not_reported_as_clean_cancel() {
+        let registry = TaskRegistry::new();
+        let id = registry
+            .create_keyed(&OWNER, "dsc", "cleanup-failed", "Working")
+            .expect("should create task");
+        assert!(registry.cancel_for_owner(&OWNER, &id));
+
+        assert_eq!(
+            registry.fail_after_cleanup_error(&id, "conditional close failed"),
+            TaskSettlement::Failed
+        );
+        let failed = registry.get(&id).expect("task should remain retained");
+        assert_eq!(failed.status, TaskStatus::Failed);
+        assert_eq!(failed.message, "conditional close failed");
     }
 
     #[test]
     fn terminal_tasks_ignore_late_complete_or_fail_updates() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "late", "Working")
+            .create_keyed(&OWNER, "t", "late", "Working")
             .expect("should succeed");
 
-        assert!(registry.cancel(&id));
-        registry.complete(&id, json!({"ok": true}));
-        registry.fail(&id, "late failure");
+        assert!(registry.cancel_for_owner(&OWNER, &id));
+        assert_eq!(
+            registry.complete(&id, json!({"ok": true})),
+            TaskSettlement::Cancelled
+        );
+        assert_eq!(
+            registry.fail(&id, "late failure"),
+            TaskSettlement::Unchanged
+        );
 
         let state = registry.get(&id).expect("task should exist");
         assert_eq!(state.status, TaskStatus::Cancelled);
@@ -506,42 +855,86 @@ mod tests {
     async fn cancel_running_task_signals_cancellation_token() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "k-cancel", "Working")
+            .create_keyed(&OWNER, "t", "k-cancel", "Working")
             .expect("should succeed");
         let cancel_token = CancellationToken::new();
         let observed = cancel_token.clone();
-        let handle = tokio::spawn(async {
+        let wrapper_dropped = Arc::new(AtomicBool::new(false));
+        let wrapper_drop_flag = wrapper_dropped.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        // Held to the end of the test: dropping a `JoinHandle` only detaches
+        // the task, so the wrapper stays alive either way, but binding it keeps
+        // the intent explicit.
+        let _handle = tokio::spawn(async move {
+            let _drop_flag = DropFlag(wrapper_drop_flag);
+            let _ = started_tx.send(());
             std::future::pending::<()>().await;
         });
-        registry.set_handle_with_cancel_token(&id, handle, cancel_token);
+        started_rx.await.expect("wrapper should start");
+        registry.set_cancel_token(&id, cancel_token);
 
-        assert!(registry.cancel(&id));
+        assert!(registry.cancel_for_owner(&OWNER, &id));
         assert!(observed.is_cancelled());
+        tokio::task::yield_now().await;
+        assert!(
+            !wrapper_dropped.load(Ordering::SeqCst),
+            "requesting cancellation must not abort the wrapper"
+        );
+        assert_eq!(
+            registry.get(&id).expect("task should exist").status,
+            TaskStatus::Running
+        );
+    }
+
+    #[test]
+    fn cancelled_lifetime_token_wins_at_operation_settlement() {
+        let registry = TaskRegistry::new();
+        let id = registry
+            .create_keyed(&OWNER, "t", "lifetime-cancel", "Working")
+            .expect("should succeed");
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        assert_eq!(
+            registry.complete_with_cancel_token(
+                &id,
+                json!({"late_result": true}),
+                &cancel_token,
+                "Cancelled after connection closed",
+            ),
+            TaskSettlement::Cancelled
+        );
+        let state = registry.get(&id).expect("task should remain retained");
+        assert_eq!(state.status, TaskStatus::Cancelled);
+        assert_eq!(state.message, "Cancelled after connection closed");
+        assert!(state.result.is_none());
     }
 
     #[tokio::test]
     async fn cancel_all_running_cancels_tokens_and_preserves_terminal_tasks() {
         let registry = TaskRegistry::new();
         let id1 = registry
-            .create_keyed("t", "k-all-1", "Working 1")
+            .create_keyed(&OWNER, "t", "k-all-1", "Working 1")
             .expect("should succeed");
         let id2 = registry
-            .create_keyed("t", "k-all-2", "Working 2")
+            .create_keyed(&OWNER, "t", "k-all-2", "Working 2")
             .expect("should succeed");
-        let completed = registry.create_completed("Done", json!({"ok": true}));
+        let completed = registry
+            .create_completed(&OWNER, "Done", json!({"ok": true}))
+            .expect("should create completed task");
 
         let cancel_token1 = CancellationToken::new();
         let cancel_token2 = CancellationToken::new();
         let observed1 = cancel_token1.clone();
         let observed2 = cancel_token2.clone();
-        let handle1 = tokio::spawn(async {
+        let _handle1 = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
-        let handle2 = tokio::spawn(async {
+        let _handle2 = tokio::spawn(async {
             std::future::pending::<()>().await;
         });
-        registry.set_handle_with_cancel_token(&id1, handle1, cancel_token1);
-        registry.set_handle_with_cancel_token(&id2, handle2, cancel_token2);
+        registry.set_cancel_token(&id1, cancel_token1);
+        registry.set_cancel_token(&id2, cancel_token2);
 
         assert_eq!(registry.cancel_all_running("Cancelled by shutdown"), 2);
         assert!(observed1.is_cancelled());
@@ -550,18 +943,34 @@ mod tests {
         let state1 = registry.get(&id1).expect("task should exist");
         let state2 = registry.get(&id2).expect("task should exist");
         let completed_state = registry.get(&completed).expect("task should exist");
-        assert_eq!(state1.status, TaskStatus::Cancelled);
-        assert_eq!(state1.message, "Cancelled by shutdown");
-        assert_eq!(state2.status, TaskStatus::Cancelled);
+        assert_eq!(state1.status, TaskStatus::Running);
+        assert_eq!(state2.status, TaskStatus::Running);
         assert_eq!(completed_state.status, TaskStatus::Completed);
         assert_eq!(registry.cancel_all_running("again"), 0);
+
+        assert_eq!(
+            registry.complete(&id1, json!({"ok": true})),
+            TaskSettlement::Cancelled
+        );
+        assert_eq!(
+            registry.fail(&id2, "worker settled with an error"),
+            TaskSettlement::Cancelled
+        );
+        assert_eq!(
+            registry.get(&id1).expect("task should exist").message,
+            "Cancelled by shutdown"
+        );
+        assert_eq!(
+            registry.get(&id2).expect("task should exist").status,
+            TaskStatus::Cancelled
+        );
     }
 
     #[test]
     fn list_all_tasks() {
         let registry = TaskRegistry::new();
-        let _ = registry.create_keyed("t", "a", "Task A");
-        let _ = registry.create_keyed("t", "b", "Task B");
+        let _ = registry.create_keyed(&OWNER, "t", "a", "Task A");
+        let _ = registry.create_keyed(&OWNER, "t", "b", "Task B");
         assert_eq!(registry.list_all().len(), 2);
     }
 
@@ -569,7 +978,7 @@ mod tests {
     fn iso_timestamp_format() {
         let registry = TaskRegistry::new();
         let id = registry
-            .create_keyed("t", "ts", "Timestamp test")
+            .create_keyed(&OWNER, "t", "ts", "Timestamp test")
             .expect("should succeed");
         let state = registry.get(&id).expect("task should exist");
         // Should match YYYY-MM-DDTHH:MM:SSZ
@@ -584,69 +993,180 @@ mod tests {
     #[test]
     fn create_completed_uses_task_prefix() {
         let registry = TaskRegistry::new();
-        let id = registry.create_completed("Done", json!({"ok": true}));
+        let id = registry
+            .create_completed(&OWNER, "Done", json!({"ok": true}))
+            .expect("should create completed task");
         assert!(id.starts_with("task-"));
         let state = registry.get(&id).expect("task should exist");
         assert_eq!(state.status, TaskStatus::Completed);
     }
 
     #[test]
-    fn inline_completed_tasks_are_capped() {
+    fn task_admission_reclaims_the_oldest_terminal_result_at_capacity() {
         let registry = TaskRegistry::new();
-        for _ in 0..(TERMINAL_TASK_CAP + 20) {
-            let _ = registry.create_completed("Done", json!({"ok": true}));
+        let mut ids = Vec::with_capacity(MAX_TASK_REGISTRY_ENTRIES);
+        for _ in 0..MAX_TASK_REGISTRY_ENTRIES {
+            ids.push(
+                registry
+                    .create_completed(&OWNER, "Done", json!({"ok": true}))
+                    .expect("entries within the bound should be admitted"),
+            );
         }
+        assert_eq!(registry.list_all().len(), MAX_TASK_REGISTRY_ENTRIES);
 
-        let tasks = registry.list_all();
-        let inline_terminal_count = tasks
-            .iter()
-            .filter(|t| t.key.is_none() && t.status != TaskStatus::Running)
-            .count();
-        assert_eq!(inline_terminal_count, TERMINAL_TASK_CAP);
+        // A registry saturated with *terminal* entries must still admit work.
+        // Rejecting here would strand every later open_dsc / background
+        // analyze_funcs for the whole retention window with nothing running.
+        let admitted = registry
+            .create_completed(&OWNER, "Admitted", json!({"ok": true}))
+            .expect("capacity must be reclaimed from the oldest terminal entry");
+
+        assert_eq!(registry.list_all().len(), MAX_TASK_REGISTRY_ENTRIES);
+        assert!(registry.get(&admitted).is_some());
+        assert!(
+            registry.get(&ids[0]).is_none(),
+            "the least recently updated terminal entry should be reclaimed"
+        );
+        assert!(
+            ids[1..].iter().all(|id| registry.get(id).is_some()),
+            "reclaiming must take only as many entries as admission needs"
+        );
     }
 
     #[test]
-    fn keyed_terminal_tasks_are_capped() {
+    fn capacity_reclaim_never_evicts_running_tasks() {
         let registry = TaskRegistry::new();
-        for i in 0..(TERMINAL_TASK_CAP + 20) {
-            let key = format!("key-{i}");
+        let mut running = Vec::with_capacity(MAX_TASK_REGISTRY_ENTRIES);
+        for index in 0..MAX_TASK_REGISTRY_ENTRIES {
+            running.push(
+                registry
+                    .create_keyed(&OWNER, "t", &format!("k-{index}"), "Working")
+                    .expect("entries within the bound should be admitted"),
+            );
+        }
+
+        assert_eq!(
+            registry.create_keyed(&OWNER, "t", "k-overflow", "Working"),
+            Err(TaskCreateError::CapacityExceeded {
+                max_entries: MAX_TASK_REGISTRY_ENTRIES
+            }),
+            "in-flight work holds its slot; admission still fails when nothing is reclaimable"
+        );
+        assert!(
+            running.iter().all(|id| registry.get(id).is_some()),
+            "running tasks must never be reclaimed"
+        );
+    }
+
+    #[test]
+    fn expired_terminal_task_frees_admission_capacity() {
+        let registry = TaskRegistry::new();
+        let mut first_id = None;
+        for index in 0..MAX_TASK_REGISTRY_ENTRIES {
             let id = registry
-                .create_keyed("t", &key, "Working")
-                .expect("should create keyed task");
-            registry.complete(&id, json!({"ok": true}));
+                .create_completed(&OWNER, "Done", json!({"index": index}))
+                .expect("entries within the bound should be admitted");
+            first_id.get_or_insert(id);
+        }
+        let first_id = first_id.expect("registry bound should be non-zero");
+        if !age_task_past_retention(&registry, &first_id) {
+            return;
         }
 
-        let tasks = registry.list_all();
-        let keyed_terminal_count = tasks
-            .iter()
-            .filter(|t| t.key.is_some() && t.status != TaskStatus::Running)
-            .count();
-        assert_eq!(keyed_terminal_count, TERMINAL_TASK_CAP);
+        let replacement = registry
+            .create_completed(&OWNER, "Replacement", json!({"ok": true}))
+            .expect("expired terminal task should free capacity");
+        assert!(registry.get(&first_id).is_none());
+        assert!(registry.get(&replacement).is_some());
+        assert_eq!(registry.list_all().len(), MAX_TASK_REGISTRY_ENTRIES);
     }
 
     #[test]
-    fn recently_completed_task_not_immediately_evicted() {
+    fn expired_terminal_tasks_are_pruned() {
         let registry = TaskRegistry::new();
-        let long_running_id = registry
-            .create_keyed("t", "long-running", "Working")
+        let expired_id = registry
+            .create_completed(&OWNER, "Expired", json!({"ok": true}))
+            .expect("should create expired fixture");
+        let retained_id = registry
+            .create_completed(&OWNER, "Retained", json!({"ok": true}))
+            .expect("should create retained fixture");
+
+        if !age_task_past_retention(&registry, &expired_id) {
+            return;
+        }
+
+        assert!(registry.get(&expired_id).is_none());
+        assert!(registry.get(&retained_id).is_some());
+    }
+
+    #[test]
+    fn running_tasks_are_not_pruned_after_retention_ttl() {
+        let registry = TaskRegistry::new();
+        let running_id = registry
+            .create_keyed(&OWNER, "t", "long-running", "Working")
             .expect("should create long-running task");
 
-        for i in 0..TERMINAL_TASK_CAP {
-            let _ = registry.create_completed("Done", json!({"idx": i}));
+        if !age_task_past_retention(&registry, &running_id) {
+            return;
         }
 
-        std::thread::sleep(Duration::from_millis(2));
-        registry.complete(&long_running_id, json!({"ok": true}));
+        assert!(registry.get(&running_id).is_some());
+    }
+
+    #[test]
+    fn task_completing_after_ttl_remains_retrievable() {
+        let registry = TaskRegistry::new();
+        let id = registry
+            .create_keyed(&OWNER, "t", "slow", "Working")
+            .expect("should create task");
+
+        if !age_task_past_retention(&registry, &id) {
+            return;
+        }
+        registry.complete(&id, json!({"ok": true}));
 
         assert!(
-            registry.get(&long_running_id).is_some(),
-            "newly completed task should remain retrievable after pruning"
+            registry.get(&id).is_some(),
+            "a task older than the TTL must survive its own completion"
         );
-        let terminal_count = registry
-            .list_all()
-            .iter()
-            .filter(|t| t.status != TaskStatus::Running)
-            .count();
-        assert_eq!(terminal_count, TERMINAL_TASK_CAP);
+    }
+
+    #[test]
+    fn task_ids_do_not_collide_across_registries() {
+        let first = TaskRegistry::new();
+        let second = TaskRegistry::new();
+        let a = first
+            .create_keyed(&OWNER, "dsc", "same-key", "Working")
+            .expect("should create task");
+        let b = second
+            .create_keyed(&OWNER, "dsc", "same-key", "Working")
+            .expect("should create task");
+
+        assert_ne!(a, b);
+        assert!(second.get(&a).is_none(), "stale IDs must not resolve");
+    }
+
+    /// Task IDs are bearer capabilities under the shared sessionless Runtime
+    /// owner: each must carry full per-task randomness, never a shared
+    /// registry tag plus a guessable counter.
+    #[test]
+    fn task_ids_are_individually_random_within_one_registry() {
+        let registry = TaskRegistry::new();
+        let a = registry
+            .create_keyed(&OWNER, "dsc", "key-a", "Working")
+            .expect("should create task");
+        let b = registry
+            .create_keyed(&OWNER, "dsc", "key-b", "Working")
+            .expect("should create task");
+
+        let random_component = |id: &str| {
+            id.strip_prefix("dsc-")
+                .expect("task id should start with its prefix")
+                .to_string()
+        };
+        let (a, b) = (random_component(&a), random_component(&b));
+        assert_eq!(a.len(), 32, "expected a full 128-bit hex component: {a}");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()), "{a}");
+        assert_ne!(a, b, "sibling tasks must not share a derivable component");
     }
 }

--- a/src/tool_registry.rs
+++ b/src/tool_registry.rs
@@ -164,7 +164,7 @@ pub static TOOL_REGISTRY: &[ToolInfo] = &[
                     (optionally specify debug_info_path). \
                     The database must be opened before using any other analysis tools. \
                     Call close_idb when finished to release database locks; in multi-client servers, coordinate before closing. \
-                    In HTTP/SSE mode, open_idb returns a close_token that must be provided to close_idb. \
+                    In HTTP/SSE mode, keep the close_token returned by open_idb for sessionless MCP 2026 or cross-session close requests; the owning legacy session can close directly. \
                     Supports timeout_secs (default 300s, max 600s). Phase transitions are observable via recent_operations. \
                     Returns metadata about the binary: file type, processor, bitness, function count, analysis_status.",
         example: r#"{"path": "/path/to/binary", "auto_analyse": false}"#,
@@ -178,8 +178,9 @@ pub static TOOL_REGISTRY: &[ToolInfo] = &[
         category: ToolCategory::Core,
         short_desc: "Open a dyld_shared_cache and load one module; use dsc_add_dylib/dsc_add_region for more",
         full_desc: "Open an Apple dyld_shared_cache file and extract a single dylib for analysis. \
-                    On IDA 9.4, opens the DSC header directly and loads images through IDA's native dscu service. \
-                    Older IDA builds keep the legacy idat background flow when a generated .i64 is needed. \
+                    A previously generated .i64 for the same DSC is reopened directly, preserving prior analysis. \
+                    Otherwise IDA 9.4 opens the DSC header directly and loads images through IDA's native dscu service; \
+                    older IDA builds keep the legacy idat background flow when a generated .i64 is needed. \
                     Use this instead of open_idb when working with dyld_shared_cache files. \
                     Optionally load additional frameworks to resolve cross-module references. \
                     To load more code modules after the initial open, call dsc_add_dylib. \
@@ -258,7 +259,7 @@ pub static TOOL_REGISTRY: &[ToolInfo] = &[
         full_desc: "Close the currently open IDA database, releasing resources. \
                     Call this when done with analysis or before opening a different database. \
                     In multi-client servers, coordinate before closing to avoid interrupting others. \
-                    In HTTP/SSE mode, provide the close_token returned by open_idb.",
+                    In HTTP/SSE mode, provide the close_token returned by open_idb unless the request is in the owning legacy session.",
         example: r#"{"close_token": "token-from-open-idb"}"#,
         default: true,
         keywords: &["close", "unload", "database"],

--- a/test/http_session_cancel.sh
+++ b/test/http_session_cancel.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# End-to-end oracle for legacy session-owned background-task cancellation on
+# single-worker HTTP: a background analyze_funcs task spawned by a legacy
+# session must remain private from a second legacy session and then terminate
+# through cancellation after its owner is DELETEd, instead of surviving as an
+# orphan that holds the shared IDA worker.
+#
+# Determinism: the single IDA worker serializes ops. A slow foreground open_idb
+# of a 50 MiB fixture is fired first (async), the background AnalyzeFuncs op
+# queues behind it, and the session is DELETEd while the open is still active
+# (observed via recent_operations, not a sleep). The worker's pre-dequeue and
+# post-auto_wait cancel checks then fail the task regardless of IDA timing.
+set -euo pipefail
+
+PORT="${PORT:-8794}"
+BIN="${MCP_HTTP_BIN:-./target/release/ida-mcp}"
+ORIGIN="${MCP_HTTP_ORIGIN:-http://localhost}"
+ALLOW_ORIGIN="${MCP_HTTP_ALLOW_ORIGIN:-http://localhost,http://127.0.0.1}"
+BIND_HOST="${MCP_HTTP_BIND_HOST:-127.0.0.1}"
+CONNECT_HOST="${MCP_HTTP_CONNECT_HOST:-127.0.0.1}"
+THRESHOLD_BYTES=$((50 * 1024 * 1024))
+MODERN_META='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"session-cancel-test","version":"0.1"},"io.modelcontextprotocol/clientCapabilities":{}}'
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -x "$BIN" ]]; then
+  echo "missing server binary: $BIN" >&2
+  exit 1
+fi
+
+if [[ ! -x fixtures/mini ]]; then
+  echo "missing fixture binary: fixtures/mini" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+server_log="$tmpdir/server.log"
+large_fixture="fixtures/mini-session-cancel"
+
+cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+  rm -f "$large_fixture" \
+    "$large_fixture.i64" "$large_fixture.idb" "$large_fixture.imcp" \
+    "$large_fixture.i64.imcp" "$large_fixture.idb.imcp" \
+    "$large_fixture.til" "$large_fixture.nam"
+}
+trap cleanup EXIT INT TERM
+
+rm -f "$large_fixture" "$large_fixture.i64" "$large_fixture.idb"
+cp fixtures/mini "$large_fixture"
+dd if=/dev/zero of="$large_fixture" bs=1 count=1 seek="$THRESHOLD_BYTES" conv=notrunc >/dev/null 2>&1
+
+curl_headers=(
+  -H "Content-Type: application/json"
+  -H "Accept: application/json, text/event-stream"
+  -H "Origin: $ORIGIN"
+)
+
+url="http://$CONNECT_HOST:$PORT/"
+
+RUST_LOG="${RUST_LOG:-info},ida_mcp=info" "$BIN" serve-http \
+  --bind "$BIND_HOST:$PORT" \
+  --allow-origin "$ALLOW_ORIGIN" \
+  >"$server_log" 2>&1 &
+server_pid=$!
+
+fail() {
+  echo "❌ $1" >&2
+  shift
+  for extra in "$@"; do
+    echo "$extra" >&2
+  done
+  echo "── server log ──" >&2
+  cat "$server_log" >&2
+  exit 1
+}
+
+wait_for_owned_listener() {
+  local expected="MCP HTTP server listening on http://$BIND_HOST:$PORT"
+  for _ in {1..600}; do
+    if grep -Fq "$expected" "$server_log"; then
+      return 0
+    fi
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  fail "spawned server did not prove ownership of $BIND_HOST:$PORT"
+}
+
+# Do not probe the port until this child has logged a successful bind. A curl
+# alone could reach an unrelated listener when the randomized port collides.
+wait_for_owned_listener
+
+extract_response_json() {
+  # Accept plain JSON and SSE framing (strip the `data: ` prefix); pick the
+  # response frame, not the first data event.
+  sed -e 's/^data: //' | jq -cR 'fromjson? | select(has("result") or has("error"))' | tail -1
+}
+
+# init_session prints the Mcp-Session-Id of a fresh legacy client to stdout.
+init_session() {
+  local headers="$tmpdir/init.h.$$"
+  local payload='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"session-cancel","version":"0.1"},"capabilities":{}}}'
+  for _ in {1..300}; do
+    if curl -sS -D "$headers" -o /dev/null "${curl_headers[@]}" -d "$payload" "$url" 2>/dev/null; then
+      local sid
+      sid="$(awk -F': ' 'tolower($1)=="mcp-session-id" {print $2}' "$headers" | tr -d '\r')"
+      if [[ -n "$sid" ]]; then
+        curl -sS "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+          -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+          "$url" >/dev/null
+        rm -f "$headers"
+        printf '%s' "$sid"
+        return 0
+      fi
+    fi
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  rm -f "$headers"
+  fail "failed to obtain Mcp-Session-Id"
+}
+
+# session_tool_text <session-id> <id> <tool> <args-json> -> tool text payload
+session_tool_text() {
+  local sid="$1" rid="$2" tool="$3" args="$4"
+  curl -sS "${curl_headers[@]}" -H "Mcp-Session-Id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":${rid},\"method\":\"tools/call\",\"params\":{\"name\":\"${tool}\",\"arguments\":${args}}}" \
+    "$url" | extract_response_json | jq -r '.result.content[0].text // empty'
+}
+
+# modern_tool_text <id> <tool> <args-json> -> tool text payload (sessionless)
+modern_tool_text() {
+  local rid="$1" tool="$2" args="$3"
+  curl -sS "${curl_headers[@]}" \
+    -H "MCP-Protocol-Version: 2026-07-28" \
+    -H "Mcp-Method: tools/call" -H "Mcp-Name: ${tool}" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":${rid},\"method\":\"tools/call\",\"params\":{\"_meta\":${MODERN_META},\"name\":\"${tool}\",\"arguments\":${args}}}" \
+    "$url" | extract_response_json | jq -r '.result.content[0].text // empty'
+}
+
+session_a="$(init_session)"
+echo "   session A: $session_a"
+
+# --- Phase 1: occupy the worker with a slow foreground open (async) ---
+curl -sS "${curl_headers[@]}" -H "Mcp-Session-Id: $session_a" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"tools/call\",\"params\":{\"name\":\"open_idb\",\"arguments\":{\"path\":\"$large_fixture\",\"auto_analyse\":false,\"timeout_secs\":600}}}" \
+  "$url" >"$tmpdir/open.out" 2>/dev/null &
+open_curl_pid=$!
+
+open_active=""
+for _ in {1..300}; do
+  ops="$(modern_tool_text 20 recent_operations '{}')"
+  if [[ -n "$ops" ]] && echo "$ops" | jq -e \
+    '.active_operation.tool == "open_idb"' >/dev/null 2>&1; then
+    open_active=1
+    break
+  fi
+  sleep 0.1
+done
+[[ -n "$open_active" ]] || fail "open_idb never became the active operation" "$ops"
+echo "   open_idb active on the worker"
+
+# --- Phase 2: queue a background analysis behind it, owned by session A ---
+analyze_text="$(session_tool_text "$session_a" 11 analyze_funcs '{"background":true}')"
+task_id="$(echo "$analyze_text" | jq -r '.task_id // empty')"
+[[ -n "$task_id" ]] || fail "analyze_funcs did not return a task_id" "$analyze_text"
+echo "   background task: $task_id"
+
+status_text="$(session_tool_text "$session_a" 12 task_status "{\"task_id\":\"$task_id\"}")"
+echo "$status_text" | jq -e '.status == "running"' >/dev/null ||
+  fail "task not running before session close" "$status_text"
+
+# --- Phase 3: session B cannot reuse, observe, or learn session A's task ---
+session_b="$(init_session)"
+echo "   session B: $session_b"
+
+other_analyze_text="$(session_tool_text "$session_b" 30 analyze_funcs '{"background":true}')"
+echo "$other_analyze_text" | grep -qi 'task handle stays with the response' ||
+  fail "session B was not rejected from session A's deduplicated work" "$other_analyze_text"
+if echo "$other_analyze_text" | grep -Fq "$task_id"; then
+  fail "session B learned session A's task_id through deduplication" "$other_analyze_text"
+fi
+
+other_status_text="$(session_tool_text "$session_b" 31 task_status "{\"task_id\":\"$task_id\"}")"
+echo "$other_status_text" | grep -q 'Unknown task_id' ||
+  fail "session B could poll session A's task" "$other_status_text"
+echo "   session B cannot reuse or poll session A's task"
+
+# --- Phase 4: close session A while its task is queued/running ---
+curl -sS -X DELETE "${curl_headers[@]}" -H "Mcp-Session-Id: $session_a" "$url" >/dev/null
+echo "   session A deleted"
+
+# --- Phase 5: server records cancellation of the now-private task ---
+# Task IDs are bearer capabilities and are deliberately never written to the
+# server log, so these oracles match on the log message alone; this test runs
+# exactly one background analysis, so the messages are unambiguous.
+cancel_log=""
+for _ in {1..360}; do
+  cancel_log="$(grep -F 'Background auto-analysis cancelled after work settled' "$server_log" | tail -1 || true)"
+  if [[ -n "$cancel_log" ]]; then
+    break
+  fi
+  sleep 0.5
+done
+
+[[ -n "$cancel_log" ]] ||
+  fail "server did not record cancellation after session close"
+if grep -Fq 'Background auto-analysis completed' "$server_log"; then
+  fail "task completed despite session close (cancel-on-disconnect regressed)"
+fi
+if grep -F "$task_id" "$server_log" >/dev/null; then
+  fail "task bearer ID leaked into the server log"
+fi
+
+echo "   task $task_id terminated through owner cancellation"
+wait "$open_curl_pid" 2>/dev/null || true
+echo "✅ HTTP session cancel test passed"

--- a/test/http_startup_failure.sh
+++ b/test/http_startup_failure.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# A server that cannot start must fail loudly, not silently.
+#
+# Both HTTP topologies used to log the bind error and return Ok(()): the
+# single-worker server additionally WEDGED, because its main thread parks in
+# run_ida_loop and nothing sends it a shutdown request once the server thread
+# gives up — leaving a process alive holding an IDA license with no listener.
+#
+# Needs no IDA license, database, or fixture: the port squatter is a pooled
+# parent (which never initializes IDA) and every start under test dies at bind.
+set -euo pipefail
+
+BIN="${MCP_HTTP_BIN:-../target/release/ida-mcp}"
+PORT="${PORT:-9990}"
+BIND_HOST="${MCP_HTTP_BIND_HOST:-127.0.0.1}"
+WATCHDOG_SECS="${WATCHDOG_SECS:-30}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "missing server binary: $BIN" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+squatter_pid=""
+
+cleanup() {
+  if [[ -n "${squatter_pid:-}" ]]; then
+    kill "$squatter_pid" >/dev/null 2>&1 || true
+    wait "$squatter_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo "❌ $1" >&2
+  shift
+  for extra in "$@"; do
+    echo "$extra" >&2
+  done
+  exit 1
+}
+
+# run_bounded <log> <secs> <args...> -> echoes the exit status; 137 means the
+# watchdog had to SIGKILL it (i.e. the process wedged). No GNU `timeout` on
+# macOS, and this must stay bash 3.2 safe.
+run_bounded() {
+  local log="$1" secs="$2"
+  shift 2
+  "$@" >"$log" 2>&1 &
+  local pid=$!
+  (
+    sleep "$secs"
+    kill -9 "$pid" >/dev/null 2>&1 || true
+  ) &
+  local watchdog=$!
+  local rc=0
+  wait "$pid" || rc=$?
+  kill "$watchdog" >/dev/null 2>&1 || true
+  wait "$watchdog" 2>/dev/null || true
+  echo "$rc"
+}
+
+# --- Squat the port. A pooled parent binds in milliseconds and takes no license.
+"$BIN" serve-http --bind "$BIND_HOST:$PORT" --max-workers 2 --min-workers 0 \
+  >"$tmpdir/squatter.log" 2>&1 &
+squatter_pid=$!
+
+for _ in $(seq 1 100); do
+  if grep -Fq "listening on" "$tmpdir/squatter.log" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$squatter_pid" 2>/dev/null; then
+    fail "port squatter exited before binding" "$(cat "$tmpdir/squatter.log")"
+  fi
+  sleep 0.1
+done
+grep -Fq "listening on" "$tmpdir/squatter.log" ||
+  fail "port squatter never bound $BIND_HOST:$PORT" "$(cat "$tmpdir/squatter.log")"
+echo "   port $PORT squatted"
+
+# --- Phase 1: single-worker must exit nonzero and must not wedge.
+single_log="$tmpdir/single-worker.log"
+single_rc="$(run_bounded "$single_log" "$WATCHDOG_SECS" \
+  "$BIN" serve-http --bind "$BIND_HOST:$PORT")"
+
+[[ "$single_rc" != "137" ]] ||
+  fail "single-worker start WEDGED on an occupied port (watchdog SIGKILL after ${WATCHDOG_SECS}s)" \
+    "$(cat "$single_log")"
+[[ "$single_rc" != "0" ]] ||
+  fail "single-worker start reported success on an occupied port" "$(cat "$single_log")"
+grep -Fq "bind failed" "$single_log" ||
+  fail "single-worker log never mentions the bind failure" "$(cat "$single_log")"
+grep -Fq "IDA worker loop finished" "$single_log" ||
+  fail "single-worker did not release its IDA worker loop" "$(cat "$single_log")"
+echo "   single-worker exited $single_rc and released the IDA worker loop"
+
+# NOTE: a follow-up assertion belongs here once IdaRequest::{Shutdown,Close}
+# skip deferred IDA initialization — today a failed start still runs
+# "Initializing IDA library on main thread", taking a license only to release
+# it, and a failing init would drop the Shutdown request and re-wedge.
+
+# --- Phase 2: pooled must exit nonzero and must not claim a clean stop.
+pooled_log="$tmpdir/pooled.log"
+pooled_rc="$(run_bounded "$pooled_log" "$WATCHDOG_SECS" \
+  "$BIN" serve-http --bind "$BIND_HOST:$PORT" --max-workers 2 --min-workers 0)"
+
+[[ "$pooled_rc" != "137" ]] ||
+  fail "pooled start hung on an occupied port" "$(cat "$pooled_log")"
+[[ "$pooled_rc" != "0" ]] ||
+  fail "pooled start reported success on an occupied port" "$(cat "$pooled_log")"
+grep -Fq "bind failed" "$pooled_log" ||
+  fail "pooled log never mentions the bind failure" "$(cat "$pooled_log")"
+! grep -Fq "Pooled HTTP server stopped" "$pooled_log" ||
+  fail "pooled start logged a clean stop it never achieved" "$(cat "$pooled_log")"
+echo "   pooled exited $pooled_rc without claiming a clean stop"
+
+echo "✅ HTTP startup failure test passed"

--- a/test/justfile
+++ b/test/justfile
@@ -212,6 +212,43 @@ test-http-recovery: fixture
         ./http_close_recovery.sh
     echo "✅ HTTP close-recovery test passed"
 
+# Verify a server that cannot bind fails loudly instead of wedging or
+# exiting zero. Needs no IDA license, database, or fixture.
+test-http-startup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    echo "🧪 Running HTTP startup failure test..."
+    PORT=$((9990 + RANDOM % 60)) \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        bash ./http_startup_failure.sh
+    echo "✅ HTTP startup failure test passed"
+
+# Verify legacy session DELETE cancels that session's background tasks on
+# single-worker HTTP (cancel-on-disconnect end-to-end oracle).
+test-session-cancel: fixture
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'cargo build --release' first"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required for session-cancel test (brew install jq)"
+        exit 1
+    fi
+    echo "🧪 Running HTTP session cancel test..."
+    PORT=$((9900 + RANDOM % 90)) \
+        RUST_LOG="{{ rust_log }}" \
+        MCP_HTTP_BIN="{{ server_bin }}" \
+        ./http_session_cancel.sh
+    echo "✅ HTTP session-cancel test passed"
+
 # Pool tests use raw fixture copies in tmpdirs instead of the shared mini.i64
 # so killed workers cannot poison later runs with stale packed fixture state.
 
@@ -403,6 +440,19 @@ test-elicitation: fixture
     echo "🧪 Running elicitation auto-background integration test..."
     RUST_LOG="{{ rust_log }}" MCP_STDIO_BIN="{{ server_bin }}" bash ./stdio_elicitation.sh
     echo "✅ Elicitation test passed"
+
+# Verify the MCP 2026 discover lifecycle over stdio and stateless HTTP, plus
+# the explicit legacy-only pooled HTTP boundary.
+test-modern:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x "{{ server_bin }}" ]; then
+        echo "Server binary not found: {{ server_bin }}"
+        echo "Run 'just build' first"
+        exit 1
+    fi
+    PORT=$((9400 + RANDOM % 400)) RUST_LOG="{{ rust_log }}" \
+        MCP_BIN="{{ server_bin }}" bash ./modern_protocol.sh
 
 # Run open_idb rebuild semantics test (Cases C and D from the rebuild=bool patch)
 # Phase 1 seeds a tmpdir .i64 with a renamed function via the raw-input path,
@@ -798,7 +848,9 @@ test-dsc dsc_path=dsc_test_path:
     if [ "$fc_after" -gt "$fc_before" ]; then
         echo "   ✓ Function count increased by $((fc_after - fc_before))"
     else
-        echo "⚠️  Function count did not increase (before=$fc_before, after=$fc_after)"
+        # Expected: this test never runs analyze_funcs, and functions only
+        # materialize after analysis. Segment count is the real assertion.
+        echo "   function count unchanged ($fc_before) — expected without analyze_funcs"
     fi
 
     send '{"jsonrpc":"2.0","id":104,"method":"tools/call","params":{"name":"segments","arguments":{}}}'
@@ -808,8 +860,16 @@ test-dsc dsc_path=dsc_test_path:
     echo "   After add: segments=$seg_after (was $seg_before)"
     if [ "$seg_after" -gt "$seg_before" ]; then
         echo "   ✓ Segment count increased by $((seg_after - seg_before))"
+    elif [ -n "$task_id" ]; then
+        # Fresh open: the added dylib was not present, so its segments must
+        # appear. No increase means dsc_add_dylib silently did nothing.
+        echo "❌ Segment count did not increase on a fresh open (before=$seg_before, after=$seg_after)"
+        cat "$log"
+        exit 1
     else
-        echo "⚠️  Segment count did not increase (before=$seg_before, after=$seg_after)"
+        # Reused database: the dylib usually persisted from an earlier run,
+        # so an idempotent re-add legitimately changes nothing.
+        echo "   segment count unchanged ($seg_before) — module already loaded in the reused database"
     fi
 
     # Phase 6: analysis_status sanity check

--- a/test/modern_protocol.sh
+++ b/test/modern_protocol.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN="${MCP_BIN:-${SERVER_BIN:-../target/debug/ida-mcp}}"
+PORT="${PORT:-9876}"
+META='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"ida-mcp-modern-test","version":"0.1"},"io.modelcontextprotocol/clientCapabilities":{"elicitation":{"form":{}},"extensions":{"io.modelcontextprotocol/tasks":{}}}}'
+LEGACY_META='{"io.modelcontextprotocol/protocolVersion":"2025-11-25","io.modelcontextprotocol/clientInfo":{"name":"ida-mcp-legacy-owner-test","version":"0.1"},"io.modelcontextprotocol/clientCapabilities":{}}'
+
+for command in curl jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "$command is required for modern protocol test" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -x "$BIN" ]]; then
+  echo "missing server binary: $BIN" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+server_pid=""
+
+cleanup_server() {
+  if [[ -z "${server_pid:-}" ]]; then
+    return
+  fi
+
+  kill "$server_pid" >/dev/null 2>&1 || true
+  for _ in {1..10}; do
+    if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.1
+  done
+  if kill -0 "$server_pid" >/dev/null 2>&1; then
+    kill -9 "$server_pid" >/dev/null 2>&1 || true
+  fi
+  wait "$server_pid" >/dev/null 2>&1 || true
+  server_pid=""
+}
+
+cleanup() {
+  cleanup_server
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+assert_json() {
+  local label="$1"
+  local payload="$2"
+  local filter="$3"
+  if ! echo "$payload" | jq -e "$filter" >/dev/null; then
+    echo "❌ $label" >&2
+    echo "$payload" | jq . >&2 2>/dev/null || echo "$payload" >&2
+    return 1
+  fi
+}
+
+wait_json_line() {
+  local log="$1"
+  local id="$2"
+  local elapsed=0
+  # 60s budget: startup covers process spawn + IDA library load + license
+  # preflight, which can exceed 10s on cold or loaded machines.
+  while [[ "$elapsed" -lt 600 ]]; do
+    local line
+    # jq -R + fromjson? skips non-JSON lines (e.g. tracing output merged into
+    # the log) instead of aborting the whole stream on the first parse error.
+    line="$(grep '"jsonrpc"' "$log" | jq -cR "fromjson? | select(.id == $id and (has(\"result\") or has(\"error\")))" 2>/dev/null | tail -1 || true)"
+    if [[ -n "$line" ]]; then
+      echo "$line"
+      return 0
+    fi
+    if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+      echo "server exited while waiting for response id $id" >&2
+      cat "$log" >&2
+      cat "$log.err" >&2 2>/dev/null || true
+      return 1
+    fi
+    sleep 0.1
+    elapsed=$((elapsed + 1))
+  done
+  echo "timed out waiting for response id $id" >&2
+  cat "$log" >&2
+  cat "$log.err" >&2 2>/dev/null || true
+  return 1
+}
+
+run_stdio_modern() {
+  local fifo="$tmpdir/stdio.fifo"
+  local log="$tmpdir/stdio.log"
+  mkfifo "$fifo"
+  # JSON-RPC stdout and tracing stderr must not share a file offset: a trace
+  # line flushed mid-response tears the response line in the log for good.
+  RUST_LOG="${RUST_LOG:-ida_mcp=info}" "$BIN" <"$fifo" >"$log" 2>"$log.err" &
+  server_pid=$!
+  exec 3>"$fifo"
+
+  printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"server/discover\",\"params\":{\"_meta\":$META}}" >&3
+  local discover
+  discover="$(wait_json_line "$log" 1)"
+  assert_json "stdio discover must advertise 2026 and the tasks extension" "$discover" \
+    '.result.resultType == "complete"
+     and (.result.supportedVersions | index("2026-07-28") != null)
+     and (.result.capabilities.extensions["io.modelcontextprotocol/tasks"] == {})'
+
+  printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{\"_meta\":$META}}" >&3
+  local tools
+  tools="$(wait_json_line "$log" 2)"
+  assert_json "stdio tools/list must include open_dsc without execution metadata" "$tools" \
+    '.result.resultType == "complete"
+     and any(.result.tools[]; .name == "open_dsc")
+     and all(.result.tools[]; has("execution") | not)'
+
+  printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"_meta\":$META,\"name\":\"tool_catalog\",\"arguments\":{\"query\":\"database lifecycle\",\"limit\":1}}}" >&3
+  local call
+  call="$(wait_json_line "$log" 3)"
+  assert_json "stdio modern tools/call must complete" "$call" \
+    '.result.resultType == "complete"
+     and .result.isError == false
+     and (.result.content[0].text | contains("tools"))'
+
+  printf '%s\n' '{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}' >&3
+  local malformed
+  malformed="$(wait_json_line "$log" 4)"
+  assert_json "incomplete request _meta must be rejected with -32602" "$malformed" \
+    '.error.code == -32602
+     and (.error.message | contains("request _meta is missing or has malformed required fields"))'
+
+  exec 3>&-
+  cleanup_server
+  echo "   stdio discover/list/call and strict request metadata passed"
+}
+
+run_stdio_legacy_owner() {
+  local fifo="$tmpdir/legacy-stdio.fifo"
+  local log="$tmpdir/legacy-stdio.log"
+  mkfifo "$fifo"
+  RUST_LOG="${RUST_LOG:-ida_mcp=info}" "$BIN" <"$fifo" >"$log" 2>"$log.err" &
+  server_pid=$!
+  exec 3>"$fifo"
+
+  printf '%s\n' '{"jsonrpc":"2.0","id":30,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"ida-mcp-legacy-owner-test","version":"0.1"},"capabilities":{}}}' >&3
+  local initialize
+  initialize="$(wait_json_line "$log" 30)"
+  assert_json "legacy stdio initialize must negotiate 2025-11-25" "$initialize" \
+    '.result.protocolVersion == "2025-11-25"'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' >&3
+
+  printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":31,\"method\":\"tools/call\",\"params\":{\"_meta\":$LEGACY_META,\"name\":\"analyze_funcs\",\"arguments\":{\"background\":true}}}" >&3
+  local analyze
+  analyze="$(wait_json_line "$log" 31)"
+  assert_json "full-metadata legacy stdio request must start a background task" "$analyze" \
+    '.result.isError == false and (.result.content[0].text | fromjson | .task_id | length > 0)'
+  local task_id
+  task_id="$(echo "$analyze" | jq -r '.result.content[0].text | fromjson | .task_id')"
+
+  printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":32,\"method\":\"tools/call\",\"params\":{\"name\":\"task_status\",\"arguments\":{\"task_id\":\"$task_id\"}}}" >&3
+  local status
+  status="$(wait_json_line "$log" 32)"
+  assert_json "metadata-free request on the same stdio connection must retain task ownership" "$status" \
+    ".result.isError == false and (.result.content[0].text | fromjson | .task_id == \"$task_id\")"
+
+  exec 3>&-
+  cleanup_server
+  echo "   legacy stdio task ownership stayed connection-scoped across metadata changes"
+}
+
+http_headers=(
+  -H "Content-Type: application/json"
+  -H "Accept: application/json, text/event-stream"
+  -H "Origin: http://localhost"
+)
+
+wait_http() {
+  local url="$1"
+  local body="$2"
+  local version="$3"
+  local method="$4"
+  local startup_pattern="$5"
+  local headers=("${http_headers[@]}" -H "MCP-Protocol-Version: $version" -H "Mcp-Method: $method")
+  local elapsed=0
+  # 60s budget: see wait_json_line.
+  while [[ "$elapsed" -lt 600 ]]; do
+    if grep -Fq "$startup_pattern" "$tmpdir/http-server.log"; then
+      break
+    fi
+    if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+      echo "HTTP server exited before proving listener ownership" >&2
+      cat "$tmpdir/http-server.log" >&2
+      return 1
+    fi
+    sleep 0.1
+    elapsed=$((elapsed + 1))
+  done
+  if ! grep -Fq "$startup_pattern" "$tmpdir/http-server.log"; then
+    echo "spawned HTTP server did not prove listener ownership" >&2
+    cat "$tmpdir/http-server.log" >&2
+    return 1
+  fi
+
+  elapsed=0
+  while [[ "$elapsed" -lt 600 ]]; do
+    if curl -sS "${headers[@]}" -d "$body" "$url" >"$tmpdir/http-ready.out" 2>/dev/null; then
+      return 0
+    fi
+    if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+      echo "owned HTTP server exited before becoming ready" >&2
+      cat "$tmpdir/http-server.log" >&2
+      return 1
+    fi
+    sleep 0.1
+    elapsed=$((elapsed + 1))
+  done
+  echo "owned HTTP server did not become ready" >&2
+  cat "$tmpdir/http-server.log" >&2
+  return 1
+}
+
+extract_http_json() {
+  local file="$1"
+  local event
+  # Pick the response frame (has result/error), not merely the first SSE data
+  # event — notifications or keep-alives may precede it on the stream.
+  event="$(sed -n 's/^data: //p' "$file" \
+    | jq -cR 'fromjson? | select(has("result") or has("error"))' 2>/dev/null \
+    | tail -1 || true)"
+  if [[ -n "$event" ]]; then
+    printf '%s\n' "$event"
+  else
+    cat "$file"
+  fi
+}
+
+run_http_modern() {
+  local url="http://127.0.0.1:$PORT/"
+  local log="$tmpdir/http-server.log"
+  local discover="{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"server/discover\",\"params\":{\"_meta\":$META}}"
+  RUST_LOG="${RUST_LOG:-info},ida_mcp=info" "$BIN" serve-http --bind "127.0.0.1:$PORT" \
+    --allow-origin "http://localhost,http://127.0.0.1" >"$log" 2>&1 &
+  server_pid=$!
+  wait_http "$url" "$discover" "2026-07-28" "server/discover" \
+    "MCP HTTP server listening on http://127.0.0.1:$PORT"
+
+  local discover_response
+  discover_response="$(extract_http_json "$tmpdir/http-ready.out")"
+  assert_json "HTTP discover must advertise 2026" "$discover_response" \
+    '.result.resultType == "complete"
+     and (.result.supportedVersions | index("2026-07-28") != null)'
+
+  local list="{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/list\",\"params\":{\"_meta\":$META}}"
+  curl -sS -D "$tmpdir/http-headers.out" "${http_headers[@]}" \
+    -H "MCP-Protocol-Version: 2026-07-28" -H "Mcp-Method: tools/list" \
+    -d "$list" "$url" >"$tmpdir/http-list.out"
+  assert_json "sessionless HTTP tools/list must complete" \
+    "$(extract_http_json "$tmpdir/http-list.out")" \
+    '.result.resultType == "complete" and any(.result.tools[]; .name == "open_idb")'
+  if grep -qi '^Mcp-Session-Id:' "$tmpdir/http-headers.out"; then
+    echo "modern HTTP response unexpectedly created a legacy session" >&2
+    exit 1
+  fi
+
+  local call="{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"tools/call\",\"params\":{\"_meta\":$META,\"name\":\"tool_catalog\",\"arguments\":{\"limit\":1}}}"
+  curl -sS "${http_headers[@]}" -H "MCP-Protocol-Version: 2026-07-28" \
+    -H "Mcp-Method: tools/call" -H "Mcp-Name: tool_catalog" \
+    -d "$call" "$url" >"$tmpdir/http-call.out"
+  assert_json "sessionless HTTP tools/call must complete" \
+    "$(extract_http_json "$tmpdir/http-call.out")" \
+    '.result.resultType == "complete" and .result.isError == false'
+
+  cleanup_server
+  echo "   default single-worker HTTP stayed sessionless for discover/list/call"
+}
+
+run_pooled_boundary() {
+  local pooled_port=$((PORT + 1))
+  local url="http://127.0.0.1:$pooled_port/"
+  local log="$tmpdir/http-server.log"
+  local legacy_meta='{"io.modelcontextprotocol/protocolVersion":"2025-11-25","io.modelcontextprotocol/clientInfo":{"name":"ida-mcp-modern-test","version":"0.1"},"io.modelcontextprotocol/clientCapabilities":{}}'
+  local discover="{\"jsonrpc\":\"2.0\",\"id\":20,\"method\":\"server/discover\",\"params\":{\"_meta\":$legacy_meta}}"
+  RUST_LOG="${RUST_LOG:-info},ida_mcp=info" "$BIN" serve-http --bind "127.0.0.1:$pooled_port" --max-workers 2 \
+    --allow-origin "http://localhost,http://127.0.0.1" >"$log" 2>&1 &
+  server_pid=$!
+  wait_http "$url" "$discover" "2025-11-25" "server/discover" \
+    "MCP pooled HTTP server listening on http://127.0.0.1:$pooled_port"
+
+  local discover_response
+  discover_response="$(extract_http_json "$tmpdir/http-ready.out")"
+  assert_json "pooled discover must advertise legacy versions only" "$discover_response" \
+    '(.result.supportedVersions | index("2025-11-25") != null)
+     and (.result.supportedVersions | index("2026-07-28") == null)'
+
+  local list="{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/list\",\"params\":{\"_meta\":$META}}"
+  local status
+  status="$(curl -sS -o "$tmpdir/pooled-reject.out" -w '%{http_code}' \
+    "${http_headers[@]}" -H "MCP-Protocol-Version: 2026-07-28" \
+    -H "Mcp-Method: tools/list" -d "$list" "$url")"
+  if [[ "$status" != "400" ]]; then
+    echo "pooled HTTP accepted MCP 2026 request (status $status)" >&2
+    cat "$tmpdir/pooled-reject.out" >&2
+    exit 1
+  fi
+  assert_json "pooled 2026 rejection must use -32022" \
+    "$(cat "$tmpdir/pooled-reject.out")" \
+    '.error.code == -32022'
+
+  # A legacy protocol version with the full 2026 inline-metadata key set is
+  # routed sessionless by rmcp, which would mint a fresh worker lease per
+  # request. The server must reject the tool call instead of leasing.
+  local inline_call="{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":\"tools/call\",\"params\":{\"_meta\":$legacy_meta,\"name\":\"tool_catalog\",\"arguments\":{\"limit\":1}}}"
+  curl -sS "${http_headers[@]}" -H "MCP-Protocol-Version: 2025-11-25" \
+    -H "Mcp-Method: tools/call" -H "Mcp-Name: tool_catalog" \
+    -d "$inline_call" "$url" >"$tmpdir/pooled-inline.out"
+  assert_json "pooled sessionless legacy-version tool call must be rejected" \
+    "$(extract_http_json "$tmpdir/pooled-inline.out")" \
+    '.error.code == -32602
+     and (.error.message | contains("legacy initialize lifecycle"))'
+
+  cleanup_server
+  echo "   pooled HTTP advertised legacy-only and rejected sessionless requests"
+}
+
+echo "🧪 Running MCP 2026 lifecycle test..."
+run_stdio_modern
+run_stdio_legacy_owner
+run_http_modern
+run_pooled_boundary
+echo "✅ MCP 2026 lifecycle test passed"

--- a/test/stdio_elicitation.sh
+++ b/test/stdio_elicitation.sh
@@ -5,6 +5,7 @@ BIN="${MCP_STDIO_BIN:-${SERVER_BIN:-../target/release/ida-mcp}}"
 THRESHOLD_BYTES=$((50 * 1024 * 1024))
 THRESHOLD_MIB=$((THRESHOLD_BYTES / 1024 / 1024))
 EXPECTED_THRESHOLD_MSG="threshold ${THRESHOLD_MIB} MiB"
+MODERN_META='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"elicitation-modern","version":"0.1"},"io.modelcontextprotocol/clientCapabilities":{"elicitation":{"form":{}}}}'
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required for elicitation test (brew install jq)" >&2
@@ -78,14 +79,14 @@ json_line_matching() {
     done <"$log"
     if ! kill -0 "$server_pid" 2>/dev/null; then
       echo "server process died while waiting for: $filter" >&2
-      cat "$log" >&2
+      dump_server_logs
       return 1
     fi
     sleep 1
     elapsed=$((elapsed + 1))
   done
   echo "timeout waiting for: $filter" >&2
-  cat "$log" >&2
+  dump_server_logs
   return 1
 }
 
@@ -142,10 +143,21 @@ start_server() {
   tmpdir="$(mktemp -d)"
   fifo_in="$tmpdir/in.fifo"
   log="$tmpdir/server.log"
+  errlog="$tmpdir/server.err.log"
   mkfifo "$fifo_in"
-  RUST_LOG="${RUST_LOG:-ida_mcp=trace}" "$BIN" <"$fifo_in" >"$log" 2>&1 &
+  # Keep JSON-RPC stdout separate from tracing stderr: with `2>&1` both
+  # writers share one file offset, and a trace line flushed mid-response
+  # tears the response line in the log, wedging the wait loops until timeout.
+  RUST_LOG="${RUST_LOG:-ida_mcp=trace}" "$BIN" <"$fifo_in" >"$log" 2>"$errlog" &
   server_pid=$!
   exec 3>"$fifo_in"
+}
+
+dump_server_logs() {
+  echo "── server stdout ──" >&2
+  cat "$log" >&2 || true
+  echo "── server stderr ──" >&2
+  cat "$errlog" >&2 || true
 }
 
 run_case() {
@@ -192,8 +204,76 @@ run_case() {
   cleanup_case
 }
 
+run_modern_case() {
+  local label="mrtr-accept"
+  current_large="fixtures/mini-${label}"
+  make_large_fixture "$current_large"
+  start_server
+
+  echo "── $label ──"
+  local first_payload
+  first_payload="$(jq -nc --arg path "$current_large" --argjson meta "$MODERN_META" '
+    {jsonrpc:"2.0", id:10, method:"tools/call", params:{
+      _meta:$meta,
+      name:"open_idb",
+      arguments:{path:$path, auto_analyse:true, timeout_secs:600}
+    }}')"
+  send "$first_payload"
+
+  local first_response request_state
+  first_response="$(wait_response 10 60)"
+  if ! echo "$first_response" | jq -e --arg threshold_msg "$EXPECTED_THRESHOLD_MSG" '
+    .result.resultType == "input_required"
+    and (.result.requestState | type == "string")
+    and .result.inputRequests.background.method == "elicitation/create"
+    and .result.inputRequests.background.params.requestedSchema.properties.background.type == "boolean"
+    and (.result.inputRequests.background.params.message | contains($threshold_msg))' >/dev/null; then
+    echo "❌ modern open_idb did not return the expected MRTR input request" >&2
+    echo "$first_response" | jq . >&2 || echo "$first_response" >&2
+    return 1
+  fi
+  request_state="$(echo "$first_response" | jq -r '.result.requestState')"
+
+  local retry_payload
+  retry_payload="$(jq -nc \
+    --arg path "$current_large" \
+    --arg state "$request_state" \
+    --argjson meta "$MODERN_META" '
+    {jsonrpc:"2.0", id:11, method:"tools/call", params:{
+      _meta:$meta,
+      name:"open_idb",
+      arguments:{path:$path, auto_analyse:true, timeout_secs:600},
+      requestState:$state,
+      inputResponses:{background:{action:"accept", content:{background:true}}}
+    }}')"
+  send "$retry_payload"
+
+  local open_resp task_id status_payload status_resp
+  open_resp="$(wait_response 11 180)"
+  if ! echo "$open_resp" | jq -e '.result.resultType == "complete"' >/dev/null; then
+    echo "❌ modern open_idb retry did not complete" >&2
+    echo "$open_resp" | jq . >&2 || echo "$open_resp" >&2
+    return 1
+  fi
+  task_id="$(assert_background_response "$open_resp" "$label")"
+  echo "   background task: $task_id"
+
+  status_payload="$(jq -nc --arg task "$task_id" --argjson meta "$MODERN_META" '
+    {jsonrpc:"2.0", id:12, method:"tools/call", params:{
+      _meta:$meta,
+      name:"task_status",
+      arguments:{task_id:$task}
+    }}')"
+  send "$status_payload"
+  status_resp="$(wait_response 12 30)"
+  assert_task_status "$status_resp" "$task_id" "$label"
+
+  cleanup_case
+}
+
 run_case "no-elicitation" '{}' "no"
 run_case "elicitation-accept" '{"elicitation":{"form":{}}}' "yes"
 run_case "elicitation-timeout" '{"elicitation":{"form":{}}}' "timeout" 10
+run_modern_case
 
 echo "✅ Elicitation auto-background test passed"


### PR DESCRIPTION
Upgrades rmcp 2.2.0 → 3.1.2 and adds the MCP `2026-07-28` sessionless protocol while keeping the legacy `initialize` lifecycles (`2024-11-05` through `2025-11-25`) working unchanged.

## Protocol support

- `server/discover` + per-request metadata lifecycle on stdio and single-worker HTTP
- MRTR sealed-state elicitation for the `open_idb` background-analysis prompt (integrity-protected `requestState`, bound to tool/path/size, 10-min TTL)
- SEP-2663 tasks extension: `tasks/get`, `tasks/update`, `tasks/cancel`, and native task handles for background `open_dsc` when the client declares the capability
- Pooled HTTP (`--max-workers > 1`) stays on legacy protocols only: its worker lease is session-affine and MCP 2026 has no session identity. The boundary is advertised via `server/discover`; sessionless inline-metadata tool calls are rejected instead of leaking a worker lease per request
- `--json-response` now applies to all sessionless dispatch; new `--max-request-body-mib` (default 16) replaces rmcp's 4 MiB body cap

## Task system

- Owner-scoped task registry: legacy sessions can only see/cancel their own tasks; sessionless requests share a runtime owner whose task IDs are unguessable bearer capabilities (never logged, never disclosed through deduplication)
- Cooperative cancellation: a cancelled task stays `working` until its IDA operation settles, then publishes the terminal state; the legacy idat subprocess is killed, reaped, and its partial output removed before `cancelled` is published
- Background DSC work is bound to a database generation, so a close/reopen refuses the stale task instead of redirecting its writes onto the new database
- Registry retention: terminal results kept up to 24 h (`ttlMs` is an upper bound); at the 256-entry cap, admission reclaims the least recently updated terminal entries rather than stranding new work; running tasks are never reclaimed
- Under `--stateless`, legacy-protocol requests also use the shared runtime owner so their background tasks survive the per-request handler

## Other fixes

- Close tokens are UUIDv4 bearer credentials (previously time+pid+counter)
- The IDA 9.4 direct DSC open path writes to a deterministic per-DSC database in temp and reopens it on subsequent `open_dsc` calls, preserving prior analysis — previously every call leaked a fresh multi-hundred-MB orphan
- HTTP bind/startup failures and stdio negotiation failures exit nonzero instead of wedging while holding an IDA license
- Every `#[instrument]` uses `skip_all`; log-capture tests prove tokens, scripts, patch bytes, and rename/comment text never reach the logs

## Testing

- `just check`: fmt, clippy `-D warnings`, 195 lib + 3 bin unit tests
- Full integration suite (23/23) on macOS against IDA 9.4, including new tests: `test-modern` (2026 lifecycle + pooled boundary), `test-session-cancel` (cancel-on-disconnect), `test-http-startup` (bind-failure exit codes, no license needed), and an MRTR round-trip in `test-elicitation`
- `test-dsc` verified both fresh-build and reuse paths against a real extracted `dyld_shared_cache_arm64e`
- Windows ARM64: build, unit tests, and HTTP integration verified on the test VM (`modern_protocol.sh` has no Windows runner — bash fd-plumbing harness limit, documented in AGENTS.md)

Docs updated: `TRANSPORTS.md` (protocol lifecycle, cancellation semantics, logging, known limitations), `TESTING.md`, `TOOLS.md`, README.