### PR TITLE
feat(open_idb): support target modes for raw blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,31 @@ decompile(address: "0x100000f00")
 tool_catalog(query: "find callers")
 ```
 
+#### Raw blob / firmware analysis
+
+Headerless blobs need an explicit IDA processor variant and load address.
+`open_idb` leaves loader selection to IDA; `.bin` inputs are detected as raw
+binaries without forcing a `file_type`:
+
+```
+open_idb(path: "~/firmware.bin",
+         processor: "arm:ARMv7-M",
+         bitness: 32,
+         base_address: "0x08000000",
+         entry_point: "0x08000100",
+         idb_out: "~/firmware.i64")
+```
+
+`bitness` accepts 16, 32, or 64 and is important when the processor variant
+does not fully determine the mode. For example, use `processor: "arm:ARMv8-A"`
+with `bitness: 64` for an AArch64 blob, or select the corresponding x86 bitness
+for `metapc`. `base_address` must be 16-byte aligned because IDA represents the
+`-b` value in paragraphs. Use a specific processor variant for multi-mode
+families; bare names such as `arm`, `metapc`, `mips`, `ppc`, or `riscv` are
+rejected rather than letting headless IDA silently choose the wrong mode. If a
+generated database already exists, set `rebuild: true` to recreate it with
+changed loader settings.
+
 #### HTTP/SSE worker pool
 
 `serve-http` keeps the existing single in-process IDA worker by default. For

--- a/src/ida/handlers/database.rs
+++ b/src/ida/handlers/database.rs
@@ -20,6 +20,23 @@ use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+const RAW_BITNESS_WORKER_ARG_PREFIX: &str = "--ida-mcp-raw-bitness=";
+
+pub(crate) fn raw_bitness_worker_arg(bitness: u32) -> String {
+    format!("{RAW_BITNESS_WORKER_ARG_PREFIX}{bitness}")
+}
+
+fn database_bitness(db: &IDB) -> u32 {
+    let meta = db.meta();
+    if meta.is_64bit() {
+        64
+    } else if meta.is_32bit_exactly() {
+        32
+    } else {
+        16
+    }
+}
+
 /// Build `DbInfo` from an open IDB.
 fn build_db_info(db: &IDB, path: &str, debug_info: Option<DebugInfoLoad>) -> DbInfo {
     let meta = db.meta();
@@ -27,13 +44,7 @@ fn build_db_info(db: &IDB, path: &str, debug_info: Option<DebugInfoLoad>) -> DbI
         path: path.to_string(),
         file_type: format!("{:?}", meta.filetype()),
         processor: db.processor().long_name(),
-        bits: if meta.is_64bit() {
-            64
-        } else if meta.is_32bit_exactly() {
-            32
-        } else {
-            16
-        },
+        bits: database_bitness(db),
         function_count: db.function_count(),
         debug_info,
         analysis_status: build_analysis_status(db),
@@ -135,8 +146,86 @@ fn init_database_args(extra_args: &[String]) -> Vec<String> {
         args.push("-A".to_string());
     }
 
-    args.extend(extra_args.iter().cloned());
+    args.extend(
+        extra_args
+            .iter()
+            .filter(|arg| !arg.starts_with(RAW_BITNESS_WORKER_ARG_PREFIX))
+            .cloned(),
+    );
     args
+}
+
+fn raw_bitness_from_extra_args(extra_args: &[String]) -> Result<Option<u32>, ToolError> {
+    let mut bitness = None;
+    for arg in extra_args {
+        let Some(value) = arg.strip_prefix(RAW_BITNESS_WORKER_ARG_PREFIX) else {
+            continue;
+        };
+        if bitness.is_some() {
+            return Err(ToolError::InvalidParams(
+                "raw blob bitness was specified more than once".to_string(),
+            ));
+        }
+        let value = value.parse::<u32>().map_err(|_| {
+            ToolError::InvalidParams("raw blob bitness must be 16, 32, or 64".to_string())
+        })?;
+        if !matches!(value, 16 | 32 | 64) {
+            return Err(ToolError::InvalidParams(
+                "raw blob bitness must be 16, 32, or 64".to_string(),
+            ));
+        }
+        bitness = Some(value);
+    }
+    Ok(bitness)
+}
+
+fn raw_bitness_script(bitness: u32) -> Result<String, ToolError> {
+    let segment_mode = match bitness {
+        16 => 0,
+        32 => 1,
+        64 => 2,
+        _ => {
+            return Err(ToolError::InvalidParams(
+                "raw blob bitness must be 16, 32, or 64".to_string(),
+            ));
+        }
+    };
+    Ok(format!(
+        concat!(
+            "import ida_ida\n",
+            "import ida_segment\n",
+            "ida_ida.inf_set_app_bitness({bitness})\n",
+            "for _index in range(ida_segment.get_segm_qty()):\n",
+            "    _segment = ida_segment.getnseg(_index)\n",
+            "    if _segment is not None and not ",
+            "ida_segment.set_segm_addressing(_segment, {segment_mode}):\n",
+            "        raise RuntimeError('failed to set segment addressing mode')\n",
+        ),
+        bitness = bitness,
+        segment_mode = segment_mode,
+    ))
+}
+
+fn configure_raw_bitness(db: &IDB, bitness: u32) -> Result<(), ToolError> {
+    let output = db.run_python(&raw_bitness_script(bitness)?)?;
+    if !output.success {
+        let mut details = output
+            .error
+            .unwrap_or_else(|| output.stderr.trim().to_string());
+        if details.is_empty() {
+            details = "unknown IDAPython failure".to_string();
+        }
+        return Err(ToolError::OpenFailed(format!(
+            "failed to configure raw blob bitness: {details}"
+        )));
+    }
+    let actual = database_bitness(db);
+    if actual != bitness {
+        return Err(ToolError::OpenFailed(format!(
+            "IDA reported {actual}-bit after requesting {bitness}-bit raw blob mode"
+        )));
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -160,6 +249,7 @@ pub fn handle_open(
     let expanded = expand_path(path);
     let debug_info_path = non_empty_trimmed(debug_info_path);
     let file_type = non_empty_trimmed(file_type);
+    let raw_bitness = raw_bitness_from_extra_args(extra_args)?;
     ensure_not_cancelled(cancel.as_ref())?;
 
     // Check if a database is already open
@@ -226,6 +316,14 @@ pub fn handle_open(
             }
         }
         raw_out_path = Some(out_path);
+    }
+
+    if raw_bitness.is_some() && (is_idb || existing_raw_idb_path.is_some()) {
+        return Err(ToolError::InvalidParams(
+            "bitness only affects newly created raw-blob databases; set rebuild=true to recreate \
+             the database with a different bitness"
+                .to_string(),
+        ));
     }
 
     let lock_target_path = raw_out_path.as_ref().unwrap_or(&expanded);
@@ -323,7 +421,9 @@ pub fn handle_open(
         );
         let opened_path = out_path.clone();
         let mut opts = IDBOpenOptions::new();
-        opts.auto_analyse(auto_analyse);
+        // IDA must not analyze the raw bytes until the application and segment
+        // bitness have been corrected for modes such as AArch32 and x86-16/32.
+        opts.auto_analyse(auto_analyse && raw_bitness.is_none());
         if let Some(ft) = file_type {
             info!(file_type = ft, "Using file type selector (-T flag)");
             opts.file_type(ft);
@@ -336,7 +436,7 @@ pub fn handle_open(
     };
     let _ = ticker_stop_tx.send(());
     let _ = ticker.join();
-    let db = match db {
+    let mut db = match db {
         Ok(db) => db,
         Err(e) => {
             release_mcp_lock_file(mcp_lock);
@@ -352,6 +452,15 @@ pub fn handle_open(
             )));
         }
     };
+    if let Some(bitness) = raw_bitness {
+        if let Err(error) = configure_raw_bitness(&db, bitness) {
+            release_mcp_lock_file(mcp_lock);
+            return Err(error);
+        }
+        if auto_analyse {
+            db.auto_wait();
+        }
+    }
     ensure_not_cancelled(cancel.as_ref())?;
     if !is_idb && auto_analyse {
         emit_progress(
@@ -502,7 +611,8 @@ mod tests {
     use crate::ida::handlers::database::{
         base_input_path_for_database, database_paths_match, existing_idb_for_raw_binary,
         existing_idb_for_raw_open, has_ida_database_extension, idb_path_for_raw_binary,
-        init_database_args, non_empty_trimmed,
+        init_database_args, non_empty_trimmed, raw_bitness_from_extra_args, raw_bitness_script,
+        raw_bitness_worker_arg,
     };
 
     #[test]
@@ -518,6 +628,29 @@ mod tests {
         let args = init_database_args(&["-Sscript.py".to_string(), "-Tpe".to_string()]);
         assert!(args.iter().any(|arg| arg == "-Sscript.py"));
         assert!(args.iter().any(|arg| arg == "-Tpe"));
+    }
+
+    #[test]
+    fn raw_bitness_worker_arg_is_parsed_but_not_forwarded_to_ida() {
+        let marker = raw_bitness_worker_arg(32);
+        let extra_args = vec!["-parm:ARMv8-A".to_string(), marker.clone()];
+
+        assert_eq!(raw_bitness_from_extra_args(&extra_args).unwrap(), Some(32));
+        assert!(!init_database_args(&extra_args).contains(&marker));
+        assert!(init_database_args(&extra_args).contains(&"-parm:ARMv8-A".to_string()));
+    }
+
+    #[test]
+    fn raw_bitness_script_maps_application_and_segment_modes() {
+        let script_16 = raw_bitness_script(16).unwrap();
+        assert!(script_16.contains("inf_set_app_bitness(16)"));
+        assert!(script_16.contains("set_segm_addressing(_segment, 0)"));
+
+        let script_64 = raw_bitness_script(64).unwrap();
+        assert!(script_64.contains("inf_set_app_bitness(64)"));
+        assert!(script_64.contains("set_segm_addressing(_segment, 2)"));
+        assert!(script_64.contains("\n    _segment ="));
+        assert!(raw_bitness_script(24).is_err());
     }
 
     #[test]

--- a/src/ida/pool.rs
+++ b/src/ida/pool.rs
@@ -2229,7 +2229,12 @@ mod tests {
     }
 
     #[test]
-    fn pooled_observed_child_args_forward_timeouts() {
+    fn pooled_observed_child_args_forward_timeouts_and_raw_blob_options() {
+        let raw_blob_args = vec![
+            "-A".to_string(),
+            "-parm:ARMv7-M".to_string(),
+            "-b800000".to_string(),
+        ];
         let open_args = open_idb_child_args(
             "/tmp/a",
             true,
@@ -2237,14 +2242,16 @@ mod tests {
             true,
             false,
             false,
-            Some("pe".to_string()),
+            Some("Binary".to_string()),
             true,
-            vec!["-A".to_string()],
+            raw_blob_args.clone(),
             Some("/tmp/a.out.i64".to_string()),
             Some(600),
         );
         assert_eq!(open_args["timeout_secs"], json!(600));
         assert_eq!(open_args["rebuild"], json!(false));
+        assert_eq!(open_args["file_type"], json!("Binary"));
+        assert_eq!(open_args["_worker_extra_args"], json!(raw_blob_args));
         assert_eq!(open_args["_worker_idb_out"], json!("/tmp/a.out.i64"));
 
         let analyze_args = analyze_funcs_child_args(Some(600), false);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -190,6 +190,76 @@ fn direct_dsc_temp_i64_path(dsc_path: &std::path::Path) -> Result<std::path::Pat
     Ok(std::env::temp_dir().join(format!("ida-mcp-dsc-{pid}-{now}-{name}.i64")))
 }
 
+fn raw_blob_open_args(
+    processor: Option<&str>,
+    base_address: Option<u64>,
+    entry_point: Option<u64>,
+) -> Result<Vec<String>, ToolError> {
+    let mut args = Vec::new();
+
+    if let Some(processor) = processor.map(str::trim).filter(|value| !value.is_empty()) {
+        if processor.len() > 128 || processor.chars().any(char::is_control) {
+            return Err(ToolError::InvalidParams(
+                "processor must be at most 128 characters and contain no control characters"
+                    .to_string(),
+            ));
+        }
+
+        let processor_lower = processor.to_ascii_lowercase();
+        let ambiguity_hint = match processor_lower.as_str() {
+            "arm" => Some(
+                "\"arm\" is ambiguous for a raw blob in headless mode; use an explicit variant \
+                 such as \"arm:ARMv7-M\" or \"arm:ARMv8-A\", plus bitness=64 for AArch64",
+            ),
+            "metapc" | "pc" => Some(
+                "\"metapc\" is ambiguous for a raw blob in headless mode; use an explicit \
+                 processor variant such as \"metapc:80386p\"",
+            ),
+            "mips" | "mipsl" | "mipsb" => Some(
+                "the selected MIPS processor is ambiguous for a raw blob in headless mode; \
+                 use an explicit processor variant (processor:variant)",
+            ),
+            "ppc" | "riscv" => Some(
+                "the selected processor has ambiguous bitness for a raw blob in headless mode; \
+                 use an explicit processor variant (processor:variant)",
+            ),
+            _ => None,
+        };
+        if let Some(hint) = ambiguity_hint {
+            return Err(ToolError::InvalidParams(hint.to_string()));
+        }
+
+        args.push(format!("-p{processor}"));
+    }
+
+    if let Some(base_address) = base_address {
+        if base_address & 0xf != 0 {
+            return Err(ToolError::InvalidParams(format!(
+                "base_address {base_address:#x} must be 16-byte aligned because IDA's -b option \
+                 uses paragraph units"
+            )));
+        }
+        args.push(format!("-b{:x}", base_address >> 4));
+    }
+
+    if let Some(entry_point) = entry_point {
+        args.push(format!("-i{entry_point:x}"));
+    }
+
+    Ok(args)
+}
+
+fn raw_blob_idb_path(input: &str, idb_out: Option<&str>) -> std::path::PathBuf {
+    if let Some(idb_out) = idb_out {
+        return crate::expand_path(idb_out);
+    }
+
+    let input = crate::expand_path(input);
+    let mut output = std::ffi::OsString::from(input.as_os_str());
+    output.push(".i64");
+    std::path::PathBuf::from(output)
+}
+
 impl TemporaryFileCleanup {
     fn new(path: std::path::PathBuf) -> Self {
         Self { path: Some(path) }
@@ -1413,6 +1483,8 @@ impl IdaMcpServer {
         description = "Open an IDA database (.i64/.idb) or raw binary (Mach-O/ELF/PE). \
         Raw binaries are saved as .i64 alongside the input and later raw-path opens reuse \
         that database unless rebuild=true is set. \
+        For a headerless blob, pass an explicit processor variant plus a 16-byte-aligned \
+        base_address; IDA keeps its normal loader auto-detection unless file_type is explicit. \
         For raw binaries, auto-analysis is OFF by default — check analysis_status; \
         call analyze_funcs(background=true) for full xrefs/decompile. \
         Returns close_token in HTTP/SSE mode (provide to close_idb). \
@@ -1437,24 +1509,97 @@ impl IdaMcpServer {
             "timeout_secs"
         ));
 
+        let input_is_database = Self::is_database_path(&path);
         let debug_info_path = req.normalized_debug_info_path();
+        let processor = req.normalized_processor();
+        let bitness = try_param!(parse_optional_unsigned::<u32>(req.bitness, "bitness"));
+        if bitness.is_some_and(|value| !matches!(value, 16 | 32 | 64)) {
+            return Ok(
+                ToolError::InvalidParams("bitness must be 16, 32, or 64".to_string())
+                    .to_tool_result(),
+            );
+        }
+        let base_address = try_param!(req
+            .base_address
+            .as_ref()
+            .map(|value| Self::value_to_exactly_one_address(value, "base_address"))
+            .transpose());
+        let entry_point = try_param!(req
+            .entry_point
+            .as_ref()
+            .map(|value| Self::value_to_exactly_one_address(value, "entry_point"))
+            .transpose());
+        let public_idb_out = req.normalized_idb_out();
+        let raw_blob_options = processor.is_some()
+            || bitness.is_some()
+            || base_address.is_some()
+            || entry_point.is_some();
+
+        if input_is_database && (raw_blob_options || public_idb_out.is_some()) {
+            return Ok(ToolError::InvalidParams(
+                "processor, bitness, base_address, entry_point, and idb_out apply only when \
+                 creating a database from a raw input"
+                    .to_string(),
+            )
+            .to_tool_result());
+        }
+        if let Some(idb_out) = public_idb_out.as_deref() {
+            let extension = std::path::Path::new(idb_out)
+                .extension()
+                .and_then(|extension| extension.to_str());
+            if idb_out.contains("..")
+                || !extension.is_some_and(|extension| {
+                    extension.eq_ignore_ascii_case("i64") || extension.eq_ignore_ascii_case("idb")
+                })
+            {
+                return Ok(ToolError::InvalidParams(
+                    "idb_out must be a traversal-free path ending in .i64 or .idb".to_string(),
+                )
+                .to_tool_result());
+            }
+        }
+        if raw_blob_options
+            && !req.rebuild.unwrap_or(false)
+            && raw_blob_idb_path(&path, public_idb_out.as_deref()).exists()
+        {
+            return Ok(ToolError::InvalidParams(
+                "processor, bitness, base_address, and entry_point only affect new raw-blob \
+                 databases; the output database already exists. Set rebuild=true to recreate it, \
+                 or omit the raw-blob options to reuse it."
+                    .to_string(),
+            )
+            .to_tool_result());
+        }
+
         let file_type = req.normalized_file_type();
-        let worker_extra_args = if matches!(self.mode, ServerMode::Worker) {
+        let mut worker_extra_args = if matches!(self.mode, ServerMode::Worker) {
             req.worker_extra_args.clone()
         } else {
             Vec::new()
         };
+        worker_extra_args.extend(try_param!(raw_blob_open_args(
+            processor.as_deref(),
+            base_address,
+            entry_point,
+        )));
+        if let Some(bitness) = bitness {
+            worker_extra_args.push(crate::ida::handlers::database::raw_bitness_worker_arg(
+                bitness,
+            ));
+        }
         let worker_idb_out = if matches!(self.mode, ServerMode::Worker) {
-            req.worker_idb_out.clone()
+            req.worker_idb_out
+                .clone()
+                .or_else(|| public_idb_out.clone())
         } else {
-            None
+            public_idb_out
         };
         let open_timeout_secs = timeout_secs.unwrap_or(300).min(MAX_TIMEOUT_SECS);
         let foreground_timeout_secs = self.foreground_timeout_secs(timeout_secs, 300);
         let user_auto_analyse = req.auto_analyse.unwrap_or(false);
         let large_input_size = if !matches!(self.mode, ServerMode::Worker)
             && user_auto_analyse
-            && !Self::is_database_path(&path)
+            && !input_is_database
         {
             Self::input_size_above_threshold(&path)
         } else {
@@ -5190,10 +5335,10 @@ mod tests {
     use crate::server::{
         apply_close_metadata, close_hint_for, dsc_open_plan, normalize_schema_value,
         operation::{OperationSnapshot, OperationStatus},
-        run_script_failure_message, run_script_succeeded, run_script_timeout_message,
-        run_script_truncate_chars, task_payload_result_value, timeout_with_child_grace,
-        tool_params_schema, DscOpenPlan, IdaMcpServer, RecentOperationsRequest, ToolCatalogRequest,
-        ToolHelpRequest, XrefsRequest,
+        raw_blob_idb_path, raw_blob_open_args, run_script_failure_message, run_script_succeeded,
+        run_script_timeout_message, run_script_truncate_chars, task_payload_result_value,
+        timeout_with_child_grace, tool_params_schema, DscOpenPlan, IdaMcpServer,
+        RecentOperationsRequest, ToolCatalogRequest, ToolHelpRequest, XrefsRequest,
     };
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
@@ -5244,6 +5389,57 @@ mod tests {
     fn xrefs_paging_rejects_negative_values() {
         assert!(IdaMcpServer::parse_xrefs_paging(&xrefs_request(Some(-1), None)).is_err());
         assert!(IdaMcpServer::parse_xrefs_paging(&xrefs_request(None, Some(-1))).is_err());
+    }
+
+    #[test]
+    fn raw_blob_open_args_select_processor_base_and_entry_point() {
+        let args = raw_blob_open_args(Some("arm:ARMv7-M"), Some(0x0800_0000), Some(0x0800_0100))
+            .expect("valid raw blob settings should produce IDA arguments");
+
+        assert_eq!(
+            args,
+            vec![
+                "-parm:ARMv7-M".to_string(),
+                "-b800000".to_string(),
+                "-i8000100".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_blob_open_args_reject_unaligned_base_address() {
+        let err = raw_blob_open_args(Some("aarch64"), Some(0x1003), None)
+            .expect_err("IDA base addresses must be paragraph aligned");
+
+        assert!(matches!(
+            err,
+            ToolError::InvalidParams(message)
+                if message.contains("16-byte aligned") && message.contains("0x1003")
+        ));
+    }
+
+    #[test]
+    fn raw_blob_open_args_reject_ambiguous_headless_processor() {
+        let err = raw_blob_open_args(Some("arm"), Some(0x0800_0000), None)
+            .expect_err("bare ARM is ambiguous for a headerless input");
+
+        assert!(matches!(
+            err,
+            ToolError::InvalidParams(message)
+                if message.contains("ambiguous") && message.contains("arm:ARMv7-M")
+        ));
+    }
+
+    #[test]
+    fn raw_blob_idb_path_uses_sidecar_or_explicit_output() {
+        assert_eq!(
+            raw_blob_idb_path("/tmp/firmware.bin", None),
+            std::path::PathBuf::from("/tmp/firmware.bin.i64")
+        );
+        assert_eq!(
+            raw_blob_idb_path("/tmp/firmware.bin", Some("/tmp/custom.i64")),
+            std::path::PathBuf::from("/tmp/custom.i64")
+        );
     }
 
     #[test]

--- a/src/server/requests.rs
+++ b/src/server/requests.rs
@@ -32,6 +32,30 @@ pub struct OpenIdbRequest {
     )]
     pub file_type: Option<String>,
     #[schemars(
+        description = "IDA processor selector for a raw blob (-p), including a variant when the \
+        processor has ambiguous modes (for example arm:ARMv7-M, arm:ARMv8-A, or metapc:80386p)."
+    )]
+    pub processor: Option<String>,
+    #[schemars(
+        description = "Raw blob application bitness (16, 32, or 64). Required when the selected \
+        processor variant does not determine the intended mode, such as AArch32 versus AArch64 or \
+        x86 real/protected/long mode."
+    )]
+    #[schemars(range(min = 16, max = 64))]
+    pub bitness: Option<i64>,
+    #[schemars(
+        description = "Raw blob load base as a string or number. Must be 16-byte aligned because \
+        IDA's -b option uses paragraph units."
+    )]
+    pub base_address: Option<Value>,
+    #[schemars(description = "Optional raw blob entry-point address (IDA -i).")]
+    pub entry_point: Option<Value>,
+    #[schemars(
+        description = "Output database path for a raw input. Defaults to <path>.i64. Empty strings \
+        are ignored."
+    )]
+    pub idb_out: Option<String>,
+    #[schemars(
         description = "Run full auto-analysis before returning (default: false). \
         For raw binaries, false returns fast with analysis incomplete; .i64/.idb ignore this. \
         Inputs >50 MiB may route to a background task (response includes analysis_task_id)."
@@ -55,6 +79,14 @@ impl OpenIdbRequest {
 
     pub fn normalized_file_type(&self) -> Option<String> {
         non_empty_trimmed(self.file_type.as_deref())
+    }
+
+    pub fn normalized_processor(&self) -> Option<String> {
+        non_empty_trimmed(self.processor.as_deref())
+    }
+
+    pub fn normalized_idb_out(&self) -> Option<String> {
+        non_empty_trimmed(self.idb_out.as_deref())
     }
 }
 
@@ -95,6 +127,11 @@ mod tests {
             force: None,
             rebuild: None,
             file_type: file_type.map(str::to_string),
+            processor: None,
+            bitness: None,
+            base_address: None,
+            entry_point: None,
+            idb_out: None,
             auto_analyse: None,
             timeout_secs: None,
             worker_extra_args: Vec::new(),
@@ -111,12 +148,20 @@ mod tests {
 
     #[test]
     fn open_idb_optional_strings_are_trimmed() {
-        let req = open_request(Some(" C:\\symbols\\sample.pdb "), Some(" pe "));
+        let mut req = open_request(Some(" C:\\symbols\\sample.pdb "), Some(" pe "));
+        req.processor = Some(" arm:ARMv7-M ".to_string());
+        req.idb_out = Some(" C:\\work\\firmware.i64 ".to_string());
+
         assert_eq!(
             req.normalized_debug_info_path(),
             Some("C:\\symbols\\sample.pdb".to_string())
         );
         assert_eq!(req.normalized_file_type(), Some("pe".to_string()));
+        assert_eq!(req.normalized_processor(), Some("arm:ARMv7-M".to_string()));
+        assert_eq!(
+            req.normalized_idb_out(),
+            Some("C:\\work\\firmware.i64".to_string())
+        );
     }
 }
 

--- a/src/tool_registry.rs
+++ b/src/tool_registry.rs
@@ -153,6 +153,13 @@ pub static TOOL_REGISTRY: &[ToolInfo] = &[
                     like Mach-O/ELF/PE. Raw binaries are saved as .i64 alongside the input; \
                     if that generated .i64 already exists, ida-mcp opens it directly instead of rebuilding. \
                     Set rebuild=true only when the raw input changed or stale analysis should be overwritten. \
+                    For a headerless blob, set processor to an explicit IDA processor variant and \
+                    bitness to 16, 32, or 64 when that variant does not uniquely select the intended \
+                    mode (for example AArch32 versus AArch64 or x86 real/protected/long mode). Set \
+                    base_address to a 16-byte-aligned load address. Loader auto-detection remains \
+                    enabled unless file_type is supplied. entry_point and idb_out are optional. Bare multi-mode processor \
+                    names such as arm or metapc are rejected because headless IDA can silently choose \
+                    the wrong architecture. \
                     Auto-analysis does NOT run by default — open returns quickly with the database \
                     loaded. Check analysis_status in the response: if auto_is_ok is false and you \
                     need xrefs/decompile, call analyze_funcs(background=true) and poll task_status. \
@@ -167,7 +174,7 @@ pub static TOOL_REGISTRY: &[ToolInfo] = &[
                     In HTTP/SSE mode, open_idb returns a close_token that must be provided to close_idb. \
                     Supports timeout_secs (default 300s, max 600s). Phase transitions are observable via recent_operations. \
                     Returns metadata about the binary: file type, processor, bitness, function count, analysis_status.",
-        example: r#"{"path": "/path/to/binary", "auto_analyse": false}"#,
+        example: r#"{"path": "/path/to/firmware.bin", "processor": "arm:ARMv7-M", "bitness": 32, "base_address": "0x08000000", "idb_out": "/path/to/firmware.i64", "auto_analyse": false}"#,
         default: true,
         keywords: &[
             "open", "load", "database", "binary", "idb", "i64", "macho", "elf", "pe",


### PR DESCRIPTION
# feat(open_idb): support target modes for raw blobs

## Summary

This PR adds explicit target configuration for headerless raw blobs opened through `open_idb`.
Callers can now select the IDA processor variant, application bitness, load address, entry point,
and output IDB path. The implementation also prevents ambiguous processor selections and rejects
stale raw-blob configurations instead of silently reusing an incompatible database.

## Motivation

IDA can auto-detect many structured formats such as ELF, Mach-O, and PE, but headerless firmware,
memory dumps, and other raw blobs do not contain enough metadata to reliably determine their target
mode. In headless operation, allowing IDA to choose a generic processor can produce an IDB with the
wrong architecture, bitness, segment addressing mode, or load address.

This change makes those decisions explicit and ensures that the requested mode is applied before
analysis starts.

## What Changed

### New `open_idb` parameters

| Parameter | Description |
| --- | --- |
| `processor` | IDA processor selector for a raw blob, including an explicit variant when required, such as `arm:ARMv7-M`, `arm:ARMv8-A`, or `metapc:80386p`. |
| `bitness` | Raw blob application bitness. Accepted values are `16`, `32`, and `64`. |
| `base_address` | Raw blob load base. The address must be 16-byte aligned because IDA's `-b` option uses paragraph units. |
| `entry_point` | Optional raw blob entry-point address. |
| `idb_out` | Optional output database path. It must end in `.i64` or `.idb`; the default is `<input>.i64`. |

Example:

```json
{
  "path": "~/firmware.bin",
  "processor": "arm:ARMv7-M",
  "bitness": 32,
  "base_address": "0x08000000",
  "entry_point": "0x08000100",
  "idb_out": "~/firmware.i64",
  "auto_analyse": false
}
```

### IDA argument translation

Raw-blob options are converted to the corresponding IDA arguments:

- `processor` becomes `-p<processor>`.
- `base_address` becomes `-b<paragraph>` after alignment validation and conversion.
- `entry_point` becomes `-i<address>`.

The existing loader auto-detection behavior remains unchanged unless the caller explicitly supplies
`file_type`.

### Ambiguous processor protection

The server now rejects bare processor names that are ambiguous in headless mode:

- `arm`
- `metapc` and `pc`
- `mips`, `mipsl`, and `mipsb`
- `ppc`
- `riscv`

Callers must provide an explicit processor variant so that IDA cannot silently select an unintended
architecture or mode. Processor values are also bounded to 128 characters and cannot contain
control characters.

### Bitness configuration before analysis

When `bitness` is supplied, raw input is initially opened with auto-analysis disabled. The worker
then runs an IDAPython configuration script that:

1. Sets the application bitness with `ida_ida.inf_set_app_bitness`.
2. Updates every segment's addressing mode with `ida_segment.set_segm_addressing`.
3. Verifies that IDA reports the requested bitness.
4. Runs `auto_wait()` only after the target mode is configured when `auto_analyse=true`.

The internal bitness marker used for worker communication is stripped before IDA command-line
arguments are constructed, so it cannot be interpreted as an unknown IDA switch.

### IDB output and reuse behavior

- Raw inputs default to a sidecar database at `<input>.i64`.
- `idb_out` supports custom `.i64` and `.idb` destinations.
- Output paths containing `..` are rejected.
- Processor, bitness, base-address, and entry-point options apply only when creating a new raw-blob
  database.
- If the target output database already exists, providing raw target options without
  `rebuild=true` returns a validation error explaining how to recreate it.
- Existing behavior is preserved when opening an existing raw database without new target options:
  the database is reused.
- Raw-target options and `idb_out` are rejected for direct `.i64`, `.idb`, and `.id0` opens.

### Worker pool support

HTTP/SSE worker mode now forwards raw processor arguments, bitness, custom IDB output paths, and the
existing timeout, file-type, and rebuild settings. Worker-only fields remain internal and are not
exposed in the public tool schema.

### Documentation and tool metadata

Updated the README, `open_idb` schema descriptions, and tool registry documentation with:

- Raw firmware analysis guidance.
- Processor-variant and bitness examples.
- Base-address alignment requirements.
- IDB reuse and `rebuild` behavior.

## Tests

Added unit coverage for:

- Processor, base-address, and entry-point argument generation.
- Rejection of unaligned base addresses.
- Rejection of ambiguous processor names.
- Default and explicit raw-blob IDB paths.
- Bitness marker parsing and filtering.
- 16-bit, 32-bit, and 64-bit IDAPython script generation.
- Worker-pool forwarding of raw-blob options.
- Normalization of the new request fields.
